### PR TITLE
Fix help message for encoder settings

### DIFF
--- a/firmware/lm32/ci.c
+++ b/firmware/lm32/ci.c
@@ -61,7 +61,7 @@ static void help_encoder(char banner)
 {
 	if(banner)
 		help_banner();
-	puts("encoder <source> <quality> - select encoder source, quality and enable it");
+	puts("encoder <quality> <source> - select encoder source, quality and enable it");
 	puts("encoder off                - disable encode");
 	puts("");
 }


### PR DESCRIPTION
That was the actual reason USB streaming was not working for me! I was trying all sorts of combinations like "encoder 1 50" "encoder 0 100", fiddling with mplayer etc for almost an hour...

Actual format is "encoder <quality> <source>" instead of "encoder <source> <quality>"
![screenshot89](https://cloud.githubusercontent.com/assets/1108318/9508988/76da43e2-4c78-11e5-9d6d-6fa77ee5bafa.png)

