### PR TITLE
Fix bug with programmer in atlys & opsis platform files

### DIFF
--- a/platforms/atlys.py
+++ b/platforms/atlys.py
@@ -592,7 +592,7 @@ class Platform(XilinxPlatform):
         elif self.programmer == "urjtag":
             return UrJTAG(cable="USBBlaster", pld="spartan-6")
         else:
-            raise ValueError("{} programmer is not supported".format(programmer))
+            raise ValueError("{} programmer is not supported".format(self.programmer))
 
     def do_finalize(self, fragment):
         XilinxPlatform.do_finalize(self, fragment)

--- a/platforms/opsis.py
+++ b/platforms/opsis.py
@@ -361,7 +361,7 @@ class Platform(XilinxPlatform):
         elif self.programmer == "urjtag":
             return UrJTAG(cable="USBBlaster", pld="spartan-6")
         else:
-            raise ValueError("{} programmer is not supported".format(programmer))
+            raise ValueError("{} programmer is not supported".format(self.programmer))
 
     def do_finalize(self, fragment):
         XilinxPlatform.do_finalize(self, fragment)


### PR DESCRIPTION
Fixes NameError when undefined programmer is used. Instead should raise ValueError as coded. Sample incorrect error output previously: "NameError: name 'programmer' is not defined"