### PR TITLE
Adding Travis-CI which builds gateware

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,14 @@ language:
 compiler:
   - gcc
 
+env:
+  matrix:
+   - BOARD=atlys TARGET=base
+   - BOARD=atlys TARGET=hdmi2usb
+   - BOARD=atlys TARGET=hdmi2ethernet
+   - BOARD=opsis TARGET=base
+   - BOARD=opsis TARGET=hdmi2usb
+
 install:
  - wget -q -O- https://raw.githubusercontent.com/mithro/travis-trusty/master/setup.sh | bash
  - chmod a+rx $PWD/.travis/*.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,10 @@ env:
    - BOARD=opsis TARGET=base
    - BOARD=opsis TARGET=hdmi2usb
 
+matrix:
+  allow_failures:
+   - env: BOARD=opsis TARGET=hdmi2usb
+
 install:
  - wget -q -O- https://raw.githubusercontent.com/mithro/travis-trusty/master/setup.sh | bash
  - chmod a+rx $PWD/.travis/*.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,6 @@ env:
    - BOARD=opsis TARGET=base
    - BOARD=opsis TARGET=hdmi2usb
 
-matrix:
-  allow_failures:
-   - env: BOARD=opsis TARGET=hdmi2usb
-
 install:
  - wget -q -O- https://raw.githubusercontent.com/mithro/travis-trusty/master/setup.sh | bash
  - chmod a+rx $PWD/.travis/*.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,9 @@ script:
 notifications:
  email:
   - hdmi2usb-spam@googlegroups.com
- irc:
-  channels:
-   - "chat.freenode.net#hdmi2usb"
-   - "chat.freenode.net#timvideos"
-  template:
-   - "[%{repository_slug}/%{branch}#%{build_number}] (%{commit}): %{message} (%{build_url})"
+# irc:
+#  channels:
+#   - "chat.freenode.net#hdmi2usb"
+#   - "chat.freenode.net#timvideos"
+#  template:
+#   - "[%{repository_slug}/%{branch}#%{build_number}] (%{commit}): %{message} (%{build_url})"

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,9 +29,9 @@ script:
 notifications:
  email:
   - hdmi2usb-spam@googlegroups.com
-# irc:
-#  channels:
-#   - "chat.freenode.net#hdmi2usb"
-#   - "chat.freenode.net#timvideos"
-#  template:
-#   - "[%{repository_slug}/%{branch}#%{build_number}] (%{commit}): %{message} (%{build_url})"
+ irc:
+  channels:
+   - "chat.freenode.net#hdmi2usb"
+   - "chat.freenode.net#timvideos"
+  template:
+   - "[%{repository_slug}/%{branch}#%{build_number}] (%{commit}): %{message} (%{build_url})"

--- a/.travis/package-xilinx-filter-strace.py
+++ b/.travis/package-xilinx-filter-strace.py
@@ -1,0 +1,108 @@
+#!/usr/bin/python
+
+import sys
+import re
+import os
+
+if "--verbose" not in sys.argv:
+	verbose = False
+	def write(*args, **kw):
+		pass
+else:
+	verbose = True
+	write = sys.stderr.write
+
+prefix = sys.argv[-1]
+prefix_re = '"(%s[^"]*)"' % prefix.replace('/', '/+')
+
+cmds = {}
+finished_cmds = {}
+waiting_on = {}
+files = set()
+
+last_pid = None
+for lineno, rawline in enumerate(sys.stdin.readlines()):
+	try:
+		bits = re.match(r"^(?P<pid>[0-9]+) (?P<line>.*?)(?P<unfinished> <unfinished \.\.\.>)?$", rawline)
+
+		pid = bits.group('pid')
+		line = bits.group('line')
+
+		if pid != last_pid:
+			if pid not in cmds:
+				if "execve" in line:
+					write("%08i: fork+exec, using new line %r\n" % (lineno, line))
+					cmds[pid] = line
+				else:
+					if last_pid in cmds:
+						last_command = cmds[last_pid] 
+					else:
+						last_command = finished_cmds[last_pid]
+					write("%08i: Not a fork+exec (%r), using last line %r\n" % (lineno, line, last_command))
+					cmds[pid] = last_command
+		last_pid = pid
+
+		# Connect together lines where the kernel switched between processes
+		# 31093 vfork( <unfinished ...>
+		# 31439 execve("/opt/Xilinx/14.7/ISE_DS/ISE/bin/lin64/unwrapped/wbtc", ["/opt/Xilinx/14.7/ISE_DS/ISE/bin/"..., "-f", "/home/tansell/foss/timvideos/hdm"...], [/* 79 vars */]) = 0
+		# 31093 <... vfork resumed> )   
+		unfinished = bits.group('unfinished')
+		assert "<unfinished ...>" not in line
+		if unfinished:
+			assert pid not in waiting_on
+			waiting_on[pid] = line + unfinished
+			continue
+		if "resumed>" in line:
+			assert pid in waiting_on
+			line = waiting_on[pid] + " " + line
+			del waiting_on[pid]
+
+		if "exited with" in line:
+			assert pid not in waiting_on
+			finished_cmds[pid] = cmds[pid]
+			del cmds[pid]
+			continue
+		else:
+			assert pid in cmds
+
+		# Command exec tracking
+		if "execve" in line and cmds[pid] != line:
+			write("%08i: Replacing %r with %r\n" % (lineno, cmds[pid], line))
+			cmds[pid] = line
+
+		# Did the syscall succeed?
+		success = "-1 ENOENT" not in line
+
+		# Does the syscall use the prefix?
+		bits = re.search(prefix_re, line)
+		if not bits:
+			continue
+
+		# Normalize the path
+		path = bits.group(1)
+		path = os.path.normpath(path)
+		if path.startswith('//'):
+			path = path[1:]
+
+		assert path.startswith(prefix)
+		
+		# Did the file exist?
+		if not success:
+			assert not os.path.exists(path)
+			continue
+		else:
+			assert os.path.exists(path)
+
+		# Skip directories
+		if os.path.isdir(path):
+			continue
+
+		write("%08i: Found %r via command %r (Previously seen: %r)\n" % (lineno, path, cmds[pid], path in files))
+
+		files.add(path)
+	except Exception as e:
+		sys.stderr.write("%08i: %r %r\n" % (lineno, e, rawline))
+		raise
+
+for filename in sorted(files):
+	print filename

--- a/.travis/package-xilinx.sh
+++ b/.travis/package-xilinx.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set -x
+set -e
+
+#XILINX_PASSPHRASE
+#RACKSPACE_USER
+#RACKSPACE_API
+
+export PREFIX="/opt/Xilinx/"
+
+TB_COMMAND="turbolift -u $RACKSPACE_USER -a $RACKSPACE_API --os-rax-auth iad upload -c xilinx"
+
+./build/migen/tools/strace_tailor.sh $PREFIX bash .travis/run.sh
+
+FILENAME="xilinx-ise-$(git describe).tar.bz2"
+echo $FILENAME
+
+tar --preserve-permissions -jcvf $FILENAME opt
+echo $XILINX_PASSPHRASE_IN | gpg --passphrase-fd 0 --cipher-algo AES256 -c $FILENAME
+
+# Upload the tar bz
+$TB_COMMAND -s . --sync --pattern-match ".*\.gpg"
+
+# Generate an index file
+md5sum *.gpg | sort -k2 > index.txt
+$TB_COMMAND -s index.txt

--- a/.travis/package-xilinx.sh
+++ b/.travis/package-xilinx.sh
@@ -25,7 +25,8 @@ export PREFIX="/opt/Xilinx/"
 # This is based on https://github.com/m-labs/migen/blob/master/tools/strace_tailor.sh
 STRACE_LOG=$BASE/strace.log
 if [ ! -f $STRACE_LOG ]; then
-	strace -e trace=file,process -f -o $STRACE_LOG bash $SETUP_DIR/run.sh
+	export PROGS=fpgalink
+	strace -e trace=file,process -f -o ${STRACE_LOG} bash $SETUP_DIR/run.sh
 fi
 
 STRACE_FILES=$BASE/strace.files.log

--- a/.travis/package-xilinx.sh
+++ b/.travis/package-xilinx.sh
@@ -3,26 +3,58 @@
 set -x
 set -e
 
-#XILINX_PASSPHRASE
-#RACKSPACE_USER
-#RACKSPACE_API
+SETUP_SRC=$(realpath ${BASH_SOURCE[0]})
+SETUP_DIR=$(dirname $SETUP_SRC)
+TOP_DIR=$(realpath $SETUP_DIR/..)
+
+for ARG in XILINX_PASSPHRASE_IN RACKSPACE_USER RACKSPACE_API; do
+	if [ -z "${!ARG}" ]; then
+		echo "$ARG not set"
+		exit 1
+	else
+		echo "$ARG='${!ARG}'"
+	fi
+done
+
+BASE=$TOP_DIR/build/package-xilinx
+echo $BASE
+mkdir -p $BASE
 
 export PREFIX="/opt/Xilinx/"
 
-TB_COMMAND="turbolift -u $RACKSPACE_USER -a $RACKSPACE_API --os-rax-auth iad upload -c xilinx"
+# This is based on https://github.com/m-labs/migen/blob/master/tools/strace_tailor.sh
+STRACE_LOG=$BASE/strace.log
+if [ ! -f $STRACE_LOG ]; then
+	strace -e trace=file,process -f -o $STRACE_LOG bash $SETUP_DIR/run.sh
+fi
 
-./build/migen/tools/strace_tailor.sh $PREFIX bash .travis/run.sh
-cp $PREFIX/14.7/ISE_DS/ISE/bin/lin64/xreport opt/Xilinx/14.7/ISE_DS/ISE/bin/lin64/
+STRACE_FILES=$BASE/strace.files.log
+cat $STRACE_LOG | python $SETUP_DIR/package-xilinx-filter-strace.py $PREFIX > $STRACE_FILES
 
-FILENAME="xilinx-ise-$(git describe).tar.bz2"
+XILINX_DIR=$BASE/xilinx-stripped
+if [ -d $XILINX_DIR ]; then
+  rm -rf $XILINX_DIR
+fi
+
+mkdir -p $XILINX_DIR
+cat $STRACE_FILES | xargs -d '\n' \
+	cp --parents --no-dereference --preserve=all -t $XILINX_DIR
+
+FILENAME="$BASE/xilinx-ise-$(git describe).tar.bz2"
 echo $FILENAME
-
-tar --preserve-permissions -jcvf $FILENAME opt
+(
+	cd $XILINX_DIR
+	tar --preserve-permissions -jcvf $FILENAME opt
+)
 echo $XILINX_PASSPHRASE_IN | gpg --passphrase-fd 0 --cipher-algo AES256 -c $FILENAME
 
-# Upload the tar bz
-$TB_COMMAND -s . --sync --pattern-match ".*\.gpg"
+(
+	cd $BASE
+	TB_COMMAND="turbolift -u $RACKSPACE_USER -a $RACKSPACE_API --os-rax-auth iad upload -c xilinx"
 
-# Generate an index file
-md5sum *.gpg | sort -k2 > index.txt
-$TB_COMMAND -s index.txt
+	# Upload the tar bz
+	$TB_COMMAND -s . --sync --pattern-match ".*\.gpg"
+	# Upload the index file
+	md5sum *.gpg | sort -k2 > index.txt
+	$TB_COMMAND -s index.txt
+)

--- a/.travis/package-xilinx.sh
+++ b/.travis/package-xilinx.sh
@@ -12,6 +12,7 @@ export PREFIX="/opt/Xilinx/"
 TB_COMMAND="turbolift -u $RACKSPACE_USER -a $RACKSPACE_API --os-rax-auth iad upload -c xilinx"
 
 ./build/migen/tools/strace_tailor.sh $PREFIX bash .travis/run.sh
+cp $PREFIX/14.7/ISE_DS/ISE/bin/lin64/xreport opt/Xilinx/14.7/ISE_DS/ISE/bin/lin64/
 
 FILENAME="xilinx-ise-$(git describe).tar.bz2"
 echo $FILENAME

--- a/.travis/run-make-gateware-filter.py
+++ b/.travis/run-make-gateware-filter.py
@@ -429,7 +429,7 @@ for lineno, rawline in enumerate(sys.stdin.xreadlines()):
 
 
 	if sline.startswith("Phase"):
-		if "REAL time:" in sline and not "unrouted":
+		if "REAL time:" in sline and not "unrouted" in sline:
 			phase, rtime = sline.split("REAL time:")
 			output(" (completed in %s)\n", rtime.strip())
 		else:

--- a/.travis/run-make-gateware-filter.py
+++ b/.travis/run-make-gateware-filter.py
@@ -1,0 +1,345 @@
+#!/usr/bin/python
+
+import collections
+import os
+import pprint
+import re
+import signal
+import subprocess
+import sys
+import threading
+import time
+
+log_file = open(sys.argv[1], 'w')
+
+# Suppressions for warning / info messages
+suppressions = [x.strip() for x in open(sys.argv[2], 'r').readlines() if not x.startswith('#')]
+pprint.pprint(suppressions)
+suppressions = [re.compile(x) for x in suppressions]
+
+top_path = os.path.normpath(os.getcwd())
+
+def output(s, *args, **kw):
+	keepalive_thread.output = True
+	if args:
+		assert not kw
+		sys.stdout.write((s % args).encode('utf-8'))
+	elif kw:
+		sys.stdout.write((s % kw).encode('utf-8'))
+	else:
+		sys.stdout.write(s.encode('utf-8'))
+
+	# Flush every second
+	if (time.time() - keepalive_thread.last_output_time) > 1:
+		sys.stdout.flush()
+
+	keepalive_thread.last_output_time = time.time()
+
+
+class KeepAliveThread(threading.Thread):
+	def __init__(self):
+		threading.Thread.__init__(self)
+		self.daemon = True
+		self.output = False
+		self.last_output_time = time.time()
+
+	def run(self):
+		while True:
+			if (time.time() - self.last_output_time) > 30:
+				output(u"\U0001F436")
+			time.sleep(1)
+
+keepalive_thread = KeepAliveThread()
+keepalive_thread.start()
+
+BUFFER_SIZE=100
+DELIM_MAJOR = "========================================================================="
+ERROR = "*~"*35+"*"
+
+linesbuffer = collections.deque()
+for i in range(0, BUFFER_SIZE):
+	linesbuffer.appendleft('')
+
+def shorten_path(line):
+	outputline = line
+	for path in re.finditer('"([^"]+)"', line):
+		pathname = os.path.normpath(path.group(1))
+		if os.path.exists(pathname) and os.path.isfile(pathname):
+			common_path = os.path.commonprefix([top_path, pathname])
+			relative_path = pathname[len(common_path)+1:]
+
+			outputline = outputline.replace(path.group(1), relative_path)
+	return outputline
+
+
+fsm_triggered = False
+found_specials = []
+
+last_path = None
+for lineno, rawline in enumerate(sys.stdin.readlines()):
+	log_file.write(rawline+'\n')
+	log_file.flush()
+
+	line = rawline.strip('\n\r')
+	sline = line.strip()
+	linesbuffer.appendleft(line)
+	while len(linesbuffer) > BUFFER_SIZE:
+		linesbuffer.pop()
+
+	if line.startswith("make"):
+		output('\n'+line+'\n')
+		continue
+
+	if not sline:
+		continue
+
+	if line.startswith("ERROR:"):
+		output("\nError detected! - %s\n%s\n%s\n%s\n", line, ERROR, "\n".join(reversed(linesbuffer)), ERROR)
+		continue
+
+	# WARNING:HDLCompiler:1016 - "/home/tansell/foss/timvideos/hdmi2usb/HDMI2USB-misoc-firmware/build/misoc/build/atlys_hdmi2usb-hdmi2usbsoc-atlys.v" Line 24382: Port I_LOCK_O is not connected to this instance
+	# WARNING:HDLCompiler:1016 - "/home/tansell/foss/timvideos/hdmi2usb/HDMI2USB-misoc-firmware/build/misoc/build/atlys_hdmi2usb-hdmi2usbsoc-atlys.v" Line 24475: Port IOCLK is not connected to this instance
+	# WARNING:Xst:3035 - Index value(s) does not match array range for signal <storage_20>, simulation mismatch.
+	# INFO:Xst:2774 - HDL ADVISOR - KEEP property attached to signal eth_rx_clk may hinder XST clustering optimizations.
+	keepalive_thread.output = False
+	if line.startswith("WARNING:"):
+		output("w")
+		continue
+	elif line.startswith("INFO:"):
+		output("i")
+		continue
+		
+	# Output a header which looks like this unless it is a summary header
+	# =========================================================================
+	# *                          HDL Parsing                                  *
+	# =========================================================================
+	if linesbuffer[0] == DELIM_MAJOR and \
+	   linesbuffer[1].startswith("*") and \
+	   linesbuffer[2] == DELIM_MAJOR:
+		if "Summary" in linesbuffer[1]:
+			continue
+		else:
+			output("\n\n%s\n%s\n%s\n", linesbuffer[0], linesbuffer[1], linesbuffer[2])
+			continue
+
+	# When we see a filename, output it. Examples;
+	# Analyzing Verilog file "/home/tansell/foss/timvideos/hdmi2usb/HDMI2USB-misoc-firmware/build/misoc/extcores/lm32/submodule/rtl/lm32_dp_ram.v" into library work
+	# Parsing verilog file "/home/tansell/foss/timvideos/hdmi2usb/HDMI2USB-misoc-firmware/build/misoc/extcores/lm32/submodule/rtl/lm32_include.v" included at line 31.
+	# Parsing module <lm32_dp_ram>.
+	# Analyzing Verilog file "/home/tansell/foss/timvideos/hdmi2usb/HDMI2USB-misoc-firmware/build/misoc/extcores/lm32/submodule/rtl/lm32_shifter.v" into library work
+	# Parsing verilog file "/home/tansell/foss/timvideos/hdmi2usb/HDMI2USB-misoc-firmware/build/misoc/extcores/lm32/submodule/rtl/lm32_include.v" included at line 50.
+	# Parsing module <lm32_shifter>.
+	#for path in re.finditer('"([^"]+)"', line):
+	#	pathname = os.path.normpath(path.group(1))
+	#	if os.path.exists(pathname) and os.path.isfile(pathname):
+	#		if pathname != last_path:
+	#			last_path = pathname
+	#			
+	#			common_path = os.path.commonprefix([top_path, pathname])
+	#			relative_path = pathname[len(common_path)+1:]
+	#
+	#			output("\n  %s ", relative_path)
+
+	#########################################################################
+	# Synthesis Options Summary && 8) Design Summary
+	###########################################################################
+	# =========================================================================
+	# *                      Synthesis Options Summary                        *
+	# =========================================================================
+	# ---- Source Parameters
+	# Input File Name                    : "atlys_hdmi2usb-hdmi2usbsoc-atlys.prj"
+	# ...
+	# ...
+	# =========================================================================
+	###########################################################################
+	# =========================================================================
+	# *                            Design Summary                             *
+	# =========================================================================
+	# ...
+	#
+	# =========================================================================
+	if line == DELIM_MAJOR:
+		summary_start = None
+		for bufferno, bufline in enumerate(linesbuffer):
+			if bufferno == 0:
+				continue
+			sbufline = bufline.strip()
+			if sbufline != DELIM_MAJOR:
+				continue
+
+			summaryline = linesbuffer[bufferno+1].strip()
+			if not summaryline.startswith("*") or "Summary" not in summaryline:
+				break
+			summary_start = bufferno+2
+			break
+
+		if summary_start:
+			output("\n")
+			for i in range(summary_start, 0, -1):
+				output("%s\n", linesbuffer[i])
+
+	#########################################################################
+	# 2) HDL Parsing
+	# -----------------------------------------------------------------------
+	# Analyzing Verilog file "/home/tansell/foss/timvideos/hdmi2usb/HDMI2USB-misoc-firmware/build/misoc/extcores/lm32/submodule/rtl/lm32_dtlb.v" into library work
+	ANALYZING_VERILOG = "Analyzing Verilog"
+	if sline.startswith(ANALYZING_VERILOG):
+		output("\n\n%s ", shorten_path(sline))
+	
+	# Parsing package <MDCT_PKG>.
+	# Parsing module <lm32_addsub>.
+	# Parsing entity <ByteStuffer>.
+	# Parsing architecture <RTL> of entity <bytestuffer>.
+	PARSING = "Parsing "
+	if sline.startswith(PARSING):
+		if sline.startswith("Parsing VHDL"):
+			output("\n\n%s ", shorten_path(sline))
+		else:
+			if sline.endswith('.'):
+				sline = sline[:-1]
+			output("\n  %s ", shorten_path(sline))
+		#bits = re.match(PARSING+"([^ ]+) .*<([^>]+)>\\.", sline)
+		#if bits:
+		#	output("\nParsing %s %s ", bits.group(1), bits.group(2))
+
+
+	#########################################################################
+	# 3) HDL Elaboration
+	# -----------------------------------------------------------------------
+	# Elaborating module <$unit_1>.
+	ELABORATION = "Elaborating "
+	if sline.startswith(ELABORATION):
+		if sline.endswith('.'):
+			sline = sline[:-1]
+		output("\n%s ", sline)
+		#bits = re.match(ELABORATION+"([^ ]+) .*?<([^>]+)>(.+from library <[^>]+>)?\\.", sline)
+		#if bits:
+		#	output("\nElaborating %s %s ", bits.group(1), bits.group(2))
+
+	# Reading initialization file
+	READING_INIT = "Reading initialization file"
+	if sline.startswith(READING_INIT):
+		if sline.endswith('.'):
+			sline = sline[:-1]
+		output("\n  %s ", sline.replace('\\"', '"'))
+
+	#########################################################################
+	# 4) HDL Synthesis
+	# -----------------------------------------------------------------------
+
+	# Synthesizing Unit <top>.
+	#    Related source file is "/home/tansell/foss/timvideos/hdmi2usb/HDMI2USB-misoc-firmware/build/misoc/build/atlys_hdmi2usb-hdmi2usbsoc-atlys.v".
+	#    Set property "register_balancing = no" for signal <ethmac_tx_cdc_graycounter0_q>.
+	#    Set property "register_balancing = no" for signal <ethmac_tx_cdc_graycounter1_q>.
+	#    Set property "register_balancing = no" for signal <ethmac_rx_cdc_graycounter0_q>.
+	SYNTH = "Synthesizing Unit"
+	if sline.startswith(SYNTH):
+		if sline.endswith('.'):
+			sline = sline[:-1]
+		output("\n%s ", sline)
+
+	RELATED_SOURCE = "Related source file is"
+	if sline.startswith(RELATED_SOURCE):
+		if sline.endswith('.'):
+			sline = sline[:-1]
+		output("\n  %s ", shorten_path(sline))
+
+	# Collect special blocks for output in summary.
+	#    Found 128x24-bit dual-port RAM <Mram_mem> for signal <mem>.
+	SPECIALS = ["RAM"]
+	if sline.startswith("Found"):
+		special_found = False
+		for special in SPECIALS:
+			if special in sline:
+				special_found = True
+				break
+		if special_found:
+			found_specials.append(sline)
+
+	#    Summary:
+	#	inferred  64 RAM(s).
+	#	inferred  16 Multiplier(s).
+	#	inferred 409 Adder/Subtractor(s).
+	#	inferred 8597 D-type flip-flop(s).
+	#	inferred 140 Comparator(s).
+	#	inferred 1536 Multiplexer(s).
+	#	inferred   6 Combinational logic shifter(s).
+	#	inferred   2 Tristate(s).
+	#	inferred  32 Finite State Machine(s).
+	# Unit <top> synthesized.
+	SUMMARY = "Summary:"
+	SYTH = "synthesized."
+	if sline.endswith(SYTH):
+		summary_start = None
+		for bufferno, bufline in enumerate(linesbuffer):
+			sbufline = bufline.strip()
+			if sbufline.endswith(SUMMARY):
+				summary_start = bufferno
+				break
+		if summary_start:
+			output("\n  Summary:\n")
+			for special in sorted(found_specials):
+				output("    %s\n", special)
+			found_specials = []
+			output("    %s\n", "--")
+			for bufferno in range(summary_start-1, 0, -1):
+				sbufline = linesbuffer[bufferno].strip()
+				output("    %s\n", sbufline[0].upper()+sbufline[1:-1])
+		output("\n")
+
+	#########################################################################
+	# 5) Advanced HDL Synthesis
+	# -----------------------------------------------------------------------
+	SYNTH_ADV = "Synthesizing (advanced) Unit"
+	if sline.startswith(SYNTH_ADV):
+		if sline.endswith('.'):
+			sline = sline[:-1]
+		output("\n%s ", sline)
+
+	#########################################################################
+	# 6) Low Level Synthesis
+	# -----------------------------------------------------------------------
+
+	# Analyzing FSM <MFsm> for best encoding.
+	# Optimizing FSM <FSM_0> on signal <clockdomainsrenamer3_state[1:2]> with user encoding.
+	if sline.startswith("Analyzing FSM") or sline.startswith("Optimizing FSM"):
+		if not fsm_triggered:
+			output("\nAnalyzing and optimizing FSMs ")
+			fsm_triggered = True
+		else:
+			output(".")
+		continue
+
+	# Optimizing unit <JpegEnc> ...
+	# Optimizing unit <RAMZ_1> ...
+	OPTIMIZING = "Optimizing unit"
+	if sline.startswith(OPTIMIZING):
+		if sline.endswith('.'):
+			sline = sline[:-1]
+		output("\n%s ", sline)
+
+	# Processing Unit <top> :
+	PROCESSING = "Processing Unit "
+	if sline.startswith(PROCESSING):
+		if sline.endswith(' :'):
+			sline = sline[:-2]
+		output("\n%s ", sline)
+
+	# Final Macro Processing ...
+	if sline == "Final Macro Processing ...":
+		output("\n\n%s\n" % sline)
+	
+
+	#########################################################################
+	# 7) Partition Report
+	# -----------------------------------------------------------------------
+	
+	# Nothing?
+
+	#########################################################################
+	# 8) Design Summary
+	# -----------------------------------------------------------------------
+
+	# If the line wasn't caught elsewhere, just output a dot.
+	if not keepalive_thread.output:
+		output(".")

--- a/.travis/run-make-gateware-suppression.regex
+++ b/.travis/run-make-gateware-suppression.regex
@@ -1,0 +1,2 @@
+# Line one
+Blah.*

--- a/.travis/run.sh
+++ b/.travis/run.sh
@@ -53,12 +53,24 @@ for BOARD in $BOARDS; do
 		echo ""
 		echo ""
 		echo ""
-		echo "- make gatewaree ($BOARD $TARGET)"
+		echo "- make gateware ($BOARD $TARGET)"
 		echo "---------------------------------------------"
 		if [ $HAVE_XILINX_ISE -eq 0 ]; then
 			echo "Skipping gateware"
 		else
 			BOARD=$BOARD TARGET=$TARGET make gateware
+		fi
+
+		if [ ! -z "$PROGS" ]; then
+			for PROG in $PROGS; do
+				echo ""
+				echo ""
+				echo ""
+				echo "- make load-gateware ($PROG $BOARD $TARGET)"
+				echo "---------------------------------------------"
+				# Allow the programming to fail.
+				PROG=$PROG BOARD=$BOARD TARGET=$TARGET make load-gateware || true
+			done
 		fi
 
 		echo ""

--- a/.travis/run.sh
+++ b/.travis/run.sh
@@ -58,7 +58,7 @@ for BOARD in $BOARDS; do
 		if [ $HAVE_XILINX_ISE -eq 0 ]; then
 			echo "Skipping gateware"
 		else
-			BOARD=$BOARD TARGET=$TARGET make gateware
+			FILTER=$PWD/.travis/run-make-gateware-filter.py BOARD=$BOARD TARGET=$TARGET make gateware
 		fi
 
 		if [ ! -z "$PROGS" ]; then

--- a/.travis/run.sh
+++ b/.travis/run.sh
@@ -2,6 +2,7 @@
 
 . scripts/setup-env.sh
 
+ls -l $XILINX_DIR/opt/Xilinx/14.7/ISE_DS/ISE/bin/lin64/xreport
 if [ -f $XILINX_DIR/opt/Xilinx/14.7/ISE_DS/ISE/bin/lin64/xreport ]; then
 	HAVE_XILINX_ISE=1
 else
@@ -11,13 +12,22 @@ fi
 set +x
 set -e
 
-BOARDS="atlys opsis"
+if [ -z "$BOARD" ]; then
+	BOARDS="atlys opsis"
+else
+	BOARDS="$BOARD"
+fi
 
 for BOARD in $BOARDS; do
-	TARGETS="base hdmi2usb"
-	# FIXME: Get hdmi2ethernet working on the Opsis
-	if [ "$BOARD" = "atlys" ]; then
-		TARGETS="$TARGETS hdmi2ethernet"
+	if [ -z "$TARGET" ]; then
+		TARGETS="base hdmi2usb"
+		# FIXME: Get hdmi2ethernet working on the Opsis
+		# https://github.com/timvideos/HDMI2USB-misoc-firmware/issues/51
+		if [ "$BOARD" = "atlys" ]; then
+			TARGETS="$TARGETS hdmi2ethernet"
+		fi
+	else
+		TARGETS="$TARGET"
 	fi
 
 	for TARGET in $TARGETS; do

--- a/.travis/run.sh
+++ b/.travis/run.sh
@@ -2,6 +2,12 @@
 
 . scripts/setup-env.sh
 
+if [ -f $XILINX_DIR/opt/Xilinx/14.7/ISE_DS/ISE/bin/lin64/xreport ]; then
+	HAVE_XILINX_ISE=1
+else
+	HAVE_XILINX_ISE=0
+fi
+
 set +x
 set -e
 
@@ -30,16 +36,20 @@ for BOARD in $BOARDS; do
 		echo ""
 		echo ""
 		echo ""
-		echo "- make gateware"
+		echo "- make firmware ($BOARD $TARGET)"
 		echo "---------------------------------------------"
-		BOARD=$BOARD TARGET=$TARGET make gateware
+		BOARD=$BOARD TARGET=$TARGET make firmware
 
 		echo ""
 		echo ""
 		echo ""
-		echo "- make firmware ($BOARD $TARGET)"
+		echo "- make gatewaree ($BOARD $TARGET)"
 		echo "---------------------------------------------"
-		BOARD=$BOARD TARGET=$TARGET make firmware
+		if [ $HAVE_XILINX_ISE -eq 0 ]; then
+			echo "Skipping gateware"
+		else
+			BOARD=$BOARD TARGET=$TARGET make gateware
+		fi
 
 		echo ""
 		echo ""

--- a/.travis/run.sh
+++ b/.travis/run.sh
@@ -29,7 +29,7 @@ for BOARD in $BOARDS; do
 	else
 		TARGETS="$TARGET"
 	fi
-
+	(
 	for TARGET in $TARGETS; do
 		echo ""
 		echo ""
@@ -69,4 +69,5 @@ for BOARD in $BOARDS; do
 		BOARD=$BOARD TARGET=$TARGET make clean
 		echo "============================================="
 	done
+	)
 done

--- a/.travis/run.sh
+++ b/.travis/run.sh
@@ -27,7 +27,12 @@ for BOARD in $BOARDS; do
 		echo "---------------------------------------------"
 		BOARD=$BOARD TARGET=$TARGET make help
 
-		# FIXME: Add ability to compile gateware.
+		echo ""
+		echo ""
+		echo ""
+		echo "- make gateware"
+		echo "---------------------------------------------"
+		BOARD=$BOARD TARGET=$TARGET make gateware
 
 		echo ""
 		echo ""

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,13 @@ HDMI2USBDIR = ../..
 PYTHON = python3
 DATE = `date +%Y_%m_%d`
 
-CMD = $(PYTHON) make.py -X $(HDMI2USBDIR) -t $(BOARD)_$(TARGET) -Ot firmware_filename $(HDMI2USBDIR)/firmware/lm32/firmware.bin -Op programmer $(PROG)
+CMD = $(PYTHON) \
+  make.py \
+  -X $(HDMI2USBDIR) \
+  -t $(BOARD)_$(TARGET) \
+  -Ot firmware_filename $(HDMI2USBDIR)/firmware/lm32/firmware.bin \
+  -Op programmer $(PROG) \
+  $(MISOC_EXTRA_CMDLINE)
 
 ifeq ($(OS),Windows_NT)
 	FLTERM = $(PYTHON) $(MSCDIR)/tools/flterm.py

--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,14 @@ MSCDIR ?= build/misoc
 PROG ?= impact
 SERIAL ?= /dev/ttyVIZ0
 TARGET ?= hdmi2usb
+FILTER ?= tee
 
 HDMI2USBDIR = ../..
 PYTHON = python3
 DATE = `date +%Y_%m_%d`
+
+# We use the special PIPESTATUS which is bash only below.
+SHELL := /bin/bash
 
 CMD = $(PYTHON) \
   make.py \
@@ -50,7 +54,8 @@ load: load-gateware load-$(TARGET)
 gateware: gateware-$(TARGET)
 	cd $(MSCDIR) && $(CMD) --csr_csv $(HDMI2USBDIR)/test/csr.csv clean
 	cp hdl/encoder/vhdl/header.hex $(MSCDIR)/build/header.hex
-	cd $(MSCDIR) && $(CMD) --csr_csv $(HDMI2USBDIR)/test/csr.csv build-csr-csv build-bitstream
+	cd $(MSCDIR) && $(CMD) --csr_csv $(HDMI2USBDIR)/test/csr.csv build-csr-csv build-bitstream \
+	| $(FILTER) $(PWD)/build/output.$(DATE).log; (exit $${PIPESTATUS[0]})
 
 load-gateware:
 	cd $(MSCDIR) && $(CMD) load-bitstream

--- a/scripts/get-env.sh
+++ b/scripts/get-env.sh
@@ -18,6 +18,8 @@ if [ ! -d $BUILD_DIR ]; then
 	mkdir -p $BUILD_DIR
 fi
 
+sudo apt-get install -y build-essential
+
 # Xilinx ISE
 
 # --------
@@ -36,7 +38,7 @@ set -x
 
 if [ -f $XILINX_PASSPHRASE_FILE ]; then
 	# Need gpg to do the unencryption
-	sudo apt-get install gnupg
+	sudo apt-get install -y gnupg
 
 	XILINX_DIR=$BUILD_DIR/Xilinx
 	if [ ! -d "$XILINX_DIR" ]; then

--- a/scripts/get-env.sh
+++ b/scripts/get-env.sh
@@ -65,6 +65,7 @@ if [ ! -z "$XILINX_PASSPHRASE" ]; then
 else
 	XILINX_DIR=/
 fi
+echo "        Xilinx directory is: $XILINX_DIR/opt/Xilinx/"
 
 # gcc+binutils for the target
 CONDA_DIR=$SETUP_DIR/build/conda

--- a/scripts/get-env.sh
+++ b/scripts/get-env.sh
@@ -76,11 +76,12 @@ if [ -f $XILINX_PASSPHRASE_FILE ]; then
 	export MACADDR=90:10:00:00:00:01
 	#export LD_PRELOAD=$XILINX_DIR/impersonate_macaddress/impersonate_macaddress.so
 	#ls -l $LD_PRELOAD
+
+	rm $XILINX_PASSPHRASE_FILE
+	trap - EXIT
 else
 	XILINX_DIR=/
 fi
-rm $XILINX_PASSPHRASE_FILE
-trap - EXIT
 echo "        Xilinx directory is: $XILINX_DIR/opt/Xilinx/"
 
 # gcc+binutils for the target

--- a/scripts/setup-env.sh
+++ b/scripts/setup-env.sh
@@ -43,6 +43,7 @@ if [ ! -z "$XILINX_PASSPHRASE" ]; then
 else
 	XILINX_DIR=/
 fi
+echo "        Xilinx directory is: $XILINX_DIR/opt/Xilinx/"
 
 # gcc+binutils for the target
 CONDA_DIR=$SETUP_DIR/build/conda

--- a/scripts/setup-env.sh
+++ b/scripts/setup-env.sh
@@ -32,7 +32,7 @@ fi
 
 # Xilinx ISE
 XILINX_DIR=$BUILD_DIR/Xilinx
-if [ -d "$XILINX_DIR" ]; then
+if [ -f "$XILINX_DIR/opt/Xilinx/14.7/ISE_DS/ISE/bin/lin64/xreport" ]; then
 	export MISOC_EXTRA_CMDLINE="-Ob ise_path $XILINX_DIR/opt/Xilinx/"
 	# Reserved MAC address from documentation block, see
 	# http://www.iana.org/assignments/ethernet-numbers/ethernet-numbers.xhtml

--- a/scripts/setup-env.sh
+++ b/scripts/setup-env.sh
@@ -8,6 +8,7 @@ SETUP_DIR=$(dirname $SETUP_SRC)
 TOP_DIR=$(realpath $SETUP_DIR/..)
 BUILD_DIR=$TOP_DIR/build
 
+
 if [ $SOURCED = 0 ]; then
   echo "You must source this script, rather then try and run it."
   echo ". $SETUP_SRC"
@@ -23,9 +24,24 @@ echo "             This script is: $SETUP_SRC"
 echo "         Firmware directory: $TOP_DIR"
 echo "         Build directory is: $BUILD_DIR"
 
+# Check the build dir
 if [ ! -d $BUILD_DIR ]; then
 	echo "Build directory not found!"
 	return
+fi
+
+# Xilinx ISE
+if [ ! -z "$XILINX_PASSPHRASE" ]; then
+	XILINX_DIR=$BUILD_DIR/Xilinx
+	export MISOC_EXTRA_CMDLINE="-Ob ise_path $XILINX_DIR/opt/Xilinx/"
+	# Reserved MAC address from documentation block, see
+	# http://www.iana.org/assignments/ethernet-numbers/ethernet-numbers.xhtml
+	export XILINXD_LICENSE_FILE=$XILINX_DIR
+	export MACADDR=90:10:00:00:00:01
+	#export LD_PRELOAD=$XILINX_DIR/impersonate_macaddress/impersonate_macaddress.so
+	#ls -l $LD_PRELOAD
+else
+	XILINX_DIR=/
 fi
 
 # gcc+binutils for the target
@@ -52,8 +68,6 @@ MAKESTUFF_DIR=$BUILD_DIR/makestuff
 export LD_LIBRARY_PATH=$MAKESTUFF_DIR/libs/libfpgalink/lin.x64/rel:$LD_LIBRARY_PATH
 export PYTHONPATH=$MAKESTUFF_DIR/libs/libfpgalink/examples/python/:$PYTHONPATH
 python3 -c "import fl" || (echo "libfpgalink broken"; return)
-
-export PATH=$PATH:/opt/Xilinx/14.7/ISE_DS/ISE/bin/lin64/
 
 alias python=python3
 

--- a/scripts/setup-env.sh
+++ b/scripts/setup-env.sh
@@ -31,8 +31,8 @@ if [ ! -d $BUILD_DIR ]; then
 fi
 
 # Xilinx ISE
-if [ ! -z "$XILINX_PASSPHRASE" ]; then
-	XILINX_DIR=$BUILD_DIR/Xilinx
+XILINX_DIR=$BUILD_DIR/Xilinx
+if [ -d "$XILINX_DIR" ]; then
 	export MISOC_EXTRA_CMDLINE="-Ob ise_path $XILINX_DIR/opt/Xilinx/"
 	# Reserved MAC address from documentation block, see
 	# http://www.iana.org/assignments/ethernet-numbers/ethernet-numbers.xhtml
@@ -44,6 +44,9 @@ else
 	XILINX_DIR=/
 fi
 echo "        Xilinx directory is: $XILINX_DIR/opt/Xilinx/"
+# FIXME: Remove this when build/migen/mibuild/xilinx/programmer.py:_create_xsvf
+# understands the $MISOC_EXTRA_CMDLINE option.
+export PATH=$PATH:$XILINX_DIR/opt/Xilinx/14.7/ISE_DS/ISE/bin/lin64
 
 # gcc+binutils for the target
 CONDA_DIR=$SETUP_DIR/build/conda


### PR DESCRIPTION
Fixes #8.

This stuff is based of the artiq stuff at https://github.com/m-labs/artiq and uses a similar method of making  a cut back Xilinx ISE which is then encrypted and **only** made avaliable to the CI system. Because of the stripped back nature of the Xilinx ISE, changes can cause build failures if they make ISE require new files that were not previously touched. The [.travis/package-xilinx.sh](https://github.com/timvideos/HDMI2USB-misoc-firmware/blob/master/.travis/package-xilinx.sh) script can be used to recreate the package from a full ISE install.

Travis continues to use the same "[quick setup scripts](https://github.com/timvideos/HDMI2USB-misoc-firmware/tree/master/scripts)" we recommend people run to get up and running. It is **important** to keep things this way so that we have testing of the setup instructions.

As the gateware takes significantly longer than the previous firmware builds, each target now builds on a separate machine.