### PR TITLE
exit if XILINX_PASSPHRASE is not set

### DIFF
--- a/scripts/get-env.sh
+++ b/scripts/get-env.sh
@@ -20,6 +20,13 @@ fi
 
 # Xilinx ISE
 
+# make sure XILINX_PASSPHRASE is set
+if [[ ! -v XILINX_PASSPHRASE ]]; then
+        echo "XILINX_PASSPHRASE is not set."
+        exit
+fi
+
+
 # --------
 # Save the passphrase to a file so we don't echo it in the logs
 XILINX_PASSPHRASE_FILE=$(tempfile)


### PR DESCRIPTION
Or is this expected to run and use the local install?

I keep burning up hours because I run bootstrap and then realize I forgot to set ...PASSPHRASE.