### PR TITLE
travis: Only announce in the HDMI2USB channel.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,5 @@ notifications:
  irc:
   channels:
    - "chat.freenode.net#hdmi2usb"
-   - "chat.freenode.net#timvideos"
   template:
    - "[%{repository_slug}/%{branch}#%{build_number}] (%{commit}): %{message} (%{build_url})"


### PR DESCRIPTION
Lets keep #timvideos for discussion and #hdmi2usb for automated messages.