### PR TITLE
scripts: More fancy prompt.

### DIFF
--- a/scripts/setup-env.sh
+++ b/scripts/setup-env.sh
@@ -134,7 +134,7 @@ export HDMI2USB_ENV=1
 # Set prompt
 ORIG_PS1="$PS1"
 hdmi2usb_prompt() {
-	P="(H2U"
+	P=""
 	if [ ! -z "$BOARD" ]; then
 		P="$P B=$BOARD"
 	fi
@@ -144,7 +144,13 @@ hdmi2usb_prompt() {
 	if [ ! -z "$PROG" ]; then
 		P="$P P=$PROG"
 	fi
-	P="$P) $ORIG_PS1"
+
+	if [ ! -z "$P" ]; then
+		P="(H2U$P) $ORIG_PS1"
+	else
+		P="(HDMI2USB) $ORIG_PS1"
+	fi
+
 	PS1=$P
 }
 PROMPT_COMMAND=hdmi2usb_prompt

--- a/scripts/setup-env.sh
+++ b/scripts/setup-env.sh
@@ -132,4 +132,19 @@ alias python=python3
 export HDMI2USB_ENV=1
 
 # Set prompt
-PS1="(HDMI2USB)$PS1"
+ORIG_PS1="$PS1"
+hdmi2usb_prompt() {
+	P="(H2U"
+	if [ ! -z "$BOARD" ]; then
+		P="$P B=$BOARD"
+	fi
+	if [ ! -z "$TARGET" ]; then
+		P="$P T=$TARGET"
+	fi
+	if [ ! -z "$PROG" ]; then
+		P="$P P=$PROG"
+	fi
+	P="$P) $ORIG_PS1"
+	PS1=$P
+}
+PROMPT_COMMAND=hdmi2usb_prompt


### PR DESCRIPTION
The prompt now looks like this;
```
(H2U) XXXX
```

But if you set any of board/target/prog you get
```
(H2U B=opsis) XXXX
# or
(H2U T=base) XXXX
```

This improves on @shenki's work in https://github.com/timvideos/HDMI2USB-misoc-firmware/issues/137