### PR TITLE
Adjusts gamma value provided in in EDID

### DIFF
--- a/firmware/lm32/edid.c
+++ b/firmware/lm32/edid.c
@@ -218,7 +218,7 @@ void generate_edid(void *out,
 	e->video_input = 0x80; /* digital */
 	e->h_image_size = timing->h_active/64;
 	e->v_image_size = timing->v_active/64;
-	e->gamma = 0xff;
+	e->gamma = 0x78;
 	e->feature_support = 0x06;
 
 	e->cc_rg_l = 0;


### PR DESCRIPTION
 * Macs looked washed out, this fixes
 * Value in-line with two other monitors EDID data

Hi @mithro, this definitely fixes the issue - verified by changing this value a few times and comparing the Color Profiles on my Mac.  This value matches the EDID on two monitors I tested, and in my eyes looks about right.