### PR TITLE
Fixing the timing propagation through PLL/DCM parts in ISE.

### DIFF
--- a/gateware/hdmi_out/__init__.py
+++ b/gateware/hdmi_out/__init__.py
@@ -11,7 +11,8 @@ from gateware.i2c import I2C
 
 
 class HDMIOut(Module, AutoCSR):
-    def __init__(self, pads, lasmim, external_clocking=None, fifo_depth=None):
+    def __init__(self, pads, lasmim, clock50=None, external_clocking=None, fifo_depth=None):
+        assert clock50 is not None or external_clocking is not None, "%r %r" % (clock50, external_clocking)
         pack_factor = lasmim.dw//bpp
 
         if hasattr(pads, "scl"):
@@ -28,7 +29,7 @@ class HDMIOut(Module, AutoCSR):
 
         cast = structuring.Cast(lasmim.dw, pixel_layout(pack_factor), reverse_to=True)
         vtg = VTG(pack_factor)
-        self.driver = Driver(pack_factor, pads, external_clocking, fifo_depth)
+        self.driver = Driver(pack_factor, pads, clock50, external_clocking, fifo_depth)
 
         g.add_connection(self.fi, vtg, source_subr=self.fi.timing_subr, sink_ep="timing")
         g.add_connection(dma_out, cast)

--- a/gateware/hdmi_out/phy.py
+++ b/gateware/hdmi_out/phy.py
@@ -62,7 +62,8 @@ class _FIFO(Module):
 
 # This assumes a 50MHz base clock
 class _Clocking(Module, AutoCSR):
-    def __init__(self, pads, external_clocking):
+    def __init__(self, pads, clock50, external_clocking):
+        assert clock50 is not None or external_clocking is not None
         if external_clocking is None:
             self._cmd_data = CSRStorage(10)
             self._send_cmd_data = CSR()
@@ -94,7 +95,7 @@ class _Clocking(Module, AutoCSR):
                 "DCM_CLKGEN",
 
                 # i_CLKIN = 50MHz
-                i_CLKIN=ClockSignal("base50"),
+                i_CLKIN=clock50,
                 p_CLKIN_PERIOD=20.0,
 
                 #  FCLKFXDV = FCLKFX / CLKFXDV_DIVIDE
@@ -258,13 +259,14 @@ class _Clocking(Module, AutoCSR):
 
 
 class Driver(Module, AutoCSR):
-    def __init__(self, pack_factor, pads, external_clocking, fifo_depth=None):
+    def __init__(self, pack_factor, pads, clock50, external_clocking, fifo_depth=None):
+        assert clock50 is not None or external_clocking is not None
         fifo = _FIFO(pack_factor, depth=fifo_depth)
         self.submodules += fifo
         self.phy = fifo.phy
         self.busy = fifo.busy
 
-        self.submodules.clocking = _Clocking(pads, external_clocking)
+        self.submodules.clocking = _Clocking(pads, clock50, external_clocking)
 
         de_r = Signal()
         self.sync.pix += de_r.eq(fifo.pix_de)

--- a/platforms/atlys.py
+++ b/platforms/atlys.py
@@ -683,7 +683,7 @@ class Platform(XilinxPlatform):
         XilinxPlatform.do_finalize(self, fragment)
         for i in range(2):
             try:
-                self.add_period_constraint(self.lookup_request("hdmi_in", i).clk_p, 12)
+                self.add_period_constraint(self.lookup_request("hdmi_in", i).clk_p, 10)
             except ConstraintError:
                 pass
 

--- a/platforms/opsis.py
+++ b/platforms/opsis.py
@@ -411,7 +411,7 @@ class Platform(XilinxPlatform):
         XilinxPlatform.do_finalize(self, fragment)
         for i in range(2):
             try:
-                self.add_period_constraint(self.lookup_request("hdmi_in", i).clk_p, 12)
+                self.add_period_constraint(self.lookup_request("hdmi_in", i).clk_p, 10)
             except ConstraintError:
                 pass
 

--- a/targets/atlys_base.py
+++ b/targets/atlys_base.py
@@ -232,11 +232,11 @@ NET "{sys_clk}" TNM_NET = "TIGsys_clk";
 NET "{periph_clk}" TNM_NET = "TIGperiph_clk";
 NET "{encoder_clk}" TNM_NET = "TIGencoder_clk";
 
-TIMESPECT "TSsys_to_periph" = FROM "TIGsys_clk" TO "TIGperiph_clk" TIG;
-TIMESPECT "TSperiph_to_sys" = FROM "TIGsys_periph" TO "TIGsys_clk" TIG;
+TIMESPEC "TSsys_to_periph" = FROM "TIGsys_clk" TO "TIGperiph_clk" TIG;
+TIMESPEC "TSperiph_to_sys" = FROM "TIGperiph_clk" TO "TIGsys_clk" TIG;
 
-TIMESPECT "TSsys_to_encoder" = FROM "TIGsys_clk" TO "TIGencoder_clk" TIG;
-TIMESPECT "TSencoder_to_sys" = FROM "TIGsys_encoder" TO "TIGsys_clk" TIG;
+TIMESPEC "TSsys_to_encoder" = FROM "TIGsys_clk" TO "TIGencoder_clk" TIG;
+TIMESPEC "TSencoder_to_sys" = FROM "TIGencoder_clk" TO "TIGsys_clk" TIG;
 """,
             sys_clk=self.crg.cd_sys.clk,
             periph_clk=self.crg.cd_periph.clk,

--- a/targets/atlys_base.py
+++ b/targets/atlys_base.py
@@ -30,18 +30,19 @@ from targets.common import *
 
 class _CRG(Module):
     def __init__(self, platform, clk_freq):
+        # Clock domains for the system (soft CPU and related components run at).
         self.clock_domains.cd_sys = ClockDomain()
+        # Clock domains for the DDR interface.
         self.clock_domains.cd_sdram_half = ClockDomain()
         self.clock_domains.cd_sdram_full_wr = ClockDomain()
         self.clock_domains.cd_sdram_full_rd = ClockDomain()
-        self.clock_domains.cd_base50 = ClockDomain()
+        # Clock domain for peripherals (such as HDMI output).
+        self.clock_domains.cd_periph = ClockDomain()
+        # Clock domain for the JPEG Encoder.
         self.clock_domains.cd_encoder = ClockDomain()
 
-        self.clk4x_wr_strb = Signal()
-        self.clk4x_rd_strb = Signal()
-
         # Input 100MHz clock
-        f0 = 100*1000000
+        f0 = 100 * MHz
         clk100 = platform.request("clk100")
         clk100a = Signal()
         # Input 100MHz clock (buffered)
@@ -56,16 +57,19 @@ class _CRG(Module):
         n, m = f.denominator, f.numerator
         assert f0/n*m == clk_freq
         p = 8
-        pll_lckd = Signal()
-        pll_fb = Signal()
 
+        # Unbuffered output signals from the PLL. They need to be buffered
+        # before feeding into the fabric.
         unbuf_sdram_full = Signal()
         unbuf_sdram_half_a = Signal()
         unbuf_sdram_half_b = Signal()
         unbuf_encoder = Signal()
         unbuf_sys = Signal()
-        unbuf_base50 = Signal()
+        unbuf_periph = Signal()
 
+        # PLL signals
+        pll_lckd = Signal()
+        pll_fb = Signal()
         self.specials.pll = Instance(
             "PLL_ADV",
             p_SIM_DEVICE="SPARTAN6", p_BANDWIDTH="OPTIMIZED", p_COMPENSATION="INTERNAL",
@@ -74,7 +78,7 @@ class _CRG(Module):
             p_DIVCLK_DIVIDE=1,
             # Input Clocks (100MHz)
             i_CLKIN1=clk100b,
-            p_CLKIN1_PERIOD=1e9/f0,
+            p_CLKIN1_PERIOD=f0.to_ns(),
             i_CLKIN2=0,
             p_CLKIN2_PERIOD=0.,
             i_CLKINSEL=1,
@@ -82,25 +86,33 @@ class _CRG(Module):
             i_CLKFBIN=pll_fb, o_CLKFBOUT=pll_fb, o_LOCKED=pll_lckd,
             p_CLK_FEEDBACK="CLKFBOUT",
             p_CLKFBOUT_MULT=m*p//n, p_CLKFBOUT_PHASE=0.,
-            # (400MHz) sdram wr rd
+            # (300MHz) sdram wr rd
             o_CLKOUT0=unbuf_sdram_full, p_CLKOUT0_DUTY_CYCLE=.5,
             p_CLKOUT0_PHASE=0., p_CLKOUT0_DIVIDE=p//4,
             # ( 66MHz) encoder
             o_CLKOUT1=unbuf_encoder, p_CLKOUT1_DUTY_CYCLE=.5,
-            p_CLKOUT1_PHASE=0., p_CLKOUT1_DIVIDE=6,
-            # (200MHz) sdram_half - sdram dqs adr ctrl
+            p_CLKOUT1_PHASE=0., p_CLKOUT1_DIVIDE=9,
+            # (150MHz) sdram_half - sdram dqs adr ctrl
             o_CLKOUT2=unbuf_sdram_half_a, p_CLKOUT2_DUTY_CYCLE=.5,
             p_CLKOUT2_PHASE=270., p_CLKOUT2_DIVIDE=p//2,
-            # (200MHz) off-chip ddr
+            # (150MHz) off-chip ddr
             o_CLKOUT3=unbuf_sdram_half_b, p_CLKOUT3_DUTY_CYCLE=.5,
             p_CLKOUT3_PHASE=250., p_CLKOUT3_DIVIDE=p//2,
-            # ( 50MHz) base50
-            o_CLKOUT4=unbuf_base50, p_CLKOUT4_DUTY_CYCLE=.5,
-            p_CLKOUT4_PHASE=0., p_CLKOUT4_DIVIDE=p//1,
-            # ( 50MHz) sysclk
+            # ( 50MHz) periph
+            o_CLKOUT4=unbuf_periph, p_CLKOUT4_DUTY_CYCLE=.5,
+            p_CLKOUT4_PHASE=0., p_CLKOUT4_DIVIDE=12,
+            # ( 75MHz) sysclk
             o_CLKOUT5=unbuf_sys, p_CLKOUT5_DUTY_CYCLE=.5,
             p_CLKOUT5_PHASE=0., p_CLKOUT5_DIVIDE=p//1,
         )
+
+        # assert the clocks turned out as requested.
+        assert_pll_clock(300 * MHz, input=f0, feedback=(m*p//n), divide=(p//4), msg="CLKOUT0")
+        assert_pll_clock( 66 * MHz, input=f0, feedback=(m*p//n), divide=(9   ), msg="CLKOUT1")
+        assert_pll_clock(150 * MHz, input=f0, feedback=(m*p//n), divide=(p//2), msg="CLKOUT2 && CLKOUT3")
+        assert_pll_clock( 50 * MHz, input=f0, feedback=(m*p//n), divide=(12  ), msg="CLKOUT4")
+        assert_pll_clock( 75 * MHz, input=f0, feedback=(m*p//n), divide=(p//1), msg="CLKOUT5")
+
         # power on reset?
         reset = ~platform.request("cpu_reset")
         self.clock_domains.cd_por = ClockDomain()
@@ -108,20 +120,28 @@ class _CRG(Module):
         self.sync.por += If(por != 0, por.eq(por - 1))
         self.specials += AsyncResetSynchronizer(self.cd_por, reset)
 
-        # sys
+        # System clock - 75MHz
         self.specials += Instance("BUFG", i_I=unbuf_sys, o_O=self.cd_sys.clk)
         self.comb += self.cd_por.clk.eq(self.cd_sys.clk)
         self.specials += AsyncResetSynchronizer(self.cd_sys, ~pll_lckd | (por > 0))
 
-        # base50
-        self.specials += Instance("BUFG", i_I=unbuf_base50, o_O=self.cd_base50.clk)
+        # Peripheral clock - 50MHz
+        # The peripheral clock is kept separate from the system clock to allow
+        # the system clock to be increased in the future.
+        self.specials += Instance("BUFG", i_I=unbuf_periph, o_O=self.cd_periph.clk)
+        self.specials += AsyncResetSynchronizer(self.cd_periph, self.cd_sys.rst)
 
-        # encoder
-        self.specials += Instance("BUFG", i_I=unbuf_encoder, o_O=self.cd_encoder.clk) # 66 MHz
+        # JPEG encoder clock - 66MHz
+        # The JPEG encoder has it's own clock as we want it to run at higher
+        # speed then the other peripherals.
+        self.specials += Instance("BUFG", i_I=unbuf_encoder, o_O=self.cd_encoder.clk)
         self.specials += AsyncResetSynchronizer(self.cd_encoder, self.cd_sys.rst)
 
         # SDRAM clocks
         # ------------------------------------------------------------------------------
+        self.clk4x_wr_strb = Signal()
+        self.clk4x_rd_strb = Signal()
+
         # sdram_full
         self.specials += Instance("BUFPLL", p_DIVIDE=4,
                                   i_PLLIN=unbuf_sdram_full, i_GCLK=self.cd_sys.clk,
@@ -144,16 +164,6 @@ class _CRG(Module):
                                   i_C0=clk_sdram_half_shifted, i_C1=~clk_sdram_half_shifted,
                                   o_Q=output_clk)
         self.specials += Instance("OBUFDS", i_I=output_clk, o_O=clk.p, o_OB=clk.n)
-
-        #dcm_base50_locked = Signal()
-        #self.specials += Instance("DCM_CLKGEN",
-        #                          p_CLKFXDV_DIVIDE=2, p_CLKFX_DIVIDE=4, p_CLKFX_MD_MAX=1.0, p_CLKFX_MULTIPLY=2,
-        #                          p_CLKIN_PERIOD=10.0, p_SPREAD_SPECTRUM="NONE", p_STARTUP_WAIT="FALSE",
-        #
-        #                          i_CLKIN=clk100a, o_CLKFX=self.cd_base50.clk,
-        #                          o_LOCKED=dcm_base50_locked,
-        #                          i_FREEZEDCM=0, i_RST=ResetSignal())
-        #self.specials += AsyncResetSynchronizer(self.cd_base50, self.cd_sys.rst | ~dcm_base50_locked)
 
 
 class BaseSoC(SDRAMSoC):
@@ -178,7 +188,7 @@ class BaseSoC(SDRAMSoC):
                  firmware_ram_size=0x10000,
                  firmware_filename=None,
                  **kwargs):
-        clk_freq = 75*1000000
+        clk_freq = 75 * MHz
         SDRAMSoC.__init__(self, platform, clk_freq,
                           integrated_rom_size=0x8000,
                           sdram_controller_settings=LASMIconSettings(l2_size=32, with_bandwidth=True),
@@ -215,19 +225,27 @@ class BaseSoC(SDRAMSoC):
         self.register_mem("spiflash", self.mem_map["spiflash"], self.spiflash.bus, size=platform.gateware_size)
 
         self.specials += Keep(self.crg.cd_sys.clk)
-        self.specials += Keep(self.crg.cd_base50.clk)
+        self.specials += Keep(self.crg.cd_periph.clk)
         platform.add_platform_command("""
 # Separate TMNs for FROM:TO TIG constraints
 NET "{sys_clk}" TNM_NET = "TIGsys_clk";
-#NET "{base50_clk}" TNM_NET = "TIGbase50_clk";
+NET "{periph_clk}" TNM_NET = "TIGperiph_clk";
+NET "{encoder_clk}" TNM_NET = "TIGencoder_clk";
+
+TIMESPECT "TSsys_to_periph" = FROM "TIGsys_clk" TO "TIGperiph_clk" TIG;
+TIMESPECT "TSperiph_to_sys" = FROM "TIGsys_periph" TO "TIGsys_clk" TIG;
+
+TIMESPECT "TSsys_to_encoder" = FROM "TIGsys_clk" TO "TIGencoder_clk" TIG;
+TIMESPECT "TSencoder_to_sys" = FROM "TIGsys_encoder" TO "TIGsys_clk" TIG;
 """,
             sys_clk=self.crg.cd_sys.clk,
-            base50_clk=self.crg.cd_base50.clk,
+            periph_clk=self.crg.cd_periph.clk,
+            encoder_clk=self.crg.cd_encoder.clk,
         )
         # These constraints are unneeded because ISE will trace through the PLL
         # block and calculate them.
-        #platform.add_period_constraint(self.crg.cd_sys.clk, math.floor(1e9/clk_freq))
-        #platform.add_period_constraint(self.crg.cd_base50.clk, 20) # 50 MHz
+        #platform.add_period_constraint(self.crg.cd_sys.clk, 13) # 13.33ns == 75 MHz
+        #platform.add_period_constraint(self.crg.cd_periph.clk, 20) # 20ns == 50 MHz
 
 
 class MiniSoC(BaseSoC):

--- a/targets/atlys_base.py
+++ b/targets/atlys_base.py
@@ -224,8 +224,10 @@ NET "{base50_clk}" TNM_NET = "TIGbase50_clk";
             sys_clk=self.crg.cd_sys.clk,
             base50_clk=self.crg.cd_base50.clk,
         )
-        platform.add_period_constraint(self.crg.cd_sys.clk, math.floor(1e9/clk_freq))
-        platform.add_period_constraint(self.crg.cd_base50.clk, 20) # 50 MHz
+        # These constraints are unneeded because ISE will trace through the PLL
+        # block and calculate them.
+        #platform.add_period_constraint(self.crg.cd_sys.clk, math.floor(1e9/clk_freq))
+        #platform.add_period_constraint(self.crg.cd_base50.clk, 20) # 50 MHz
 
 
 class MiniSoC(BaseSoC):

--- a/targets/atlys_base.py
+++ b/targets/atlys_base.py
@@ -1,4 +1,5 @@
 # Support for the Digilent Atlys board - digilentinc.com/atlys/
+import math
 import struct
 from fractions import Fraction
 
@@ -39,61 +40,101 @@ class _CRG(Module):
         self.clk4x_wr_strb = Signal()
         self.clk4x_rd_strb = Signal()
 
+        # Input 100MHz clock
         f0 = 100*1000000
         clk100 = platform.request("clk100")
         clk100a = Signal()
+        # Input 100MHz clock (buffered)
         self.specials += Instance("IBUFG", i_I=clk100, o_O=clk100a)
         clk100b = Signal()
-        self.specials += Instance("BUFIO2", p_DIVIDE=1,
-                                  p_DIVIDE_BYPASS="TRUE", p_I_INVERT="FALSE",
-                                  i_I=clk100a, o_DIVCLK=clk100b)
+        self.specials += Instance(
+            "BUFIO2", p_DIVIDE=1,
+            p_DIVIDE_BYPASS="TRUE", p_I_INVERT="FALSE",
+            i_I=clk100a, o_DIVCLK=clk100b)
+
         f = Fraction(int(clk_freq), int(f0))
         n, m = f.denominator, f.numerator
         assert f0/n*m == clk_freq
         p = 8
         pll_lckd = Signal()
         pll_fb = Signal()
-        pll = Signal(6)
-        self.specials.pll = Instance("PLL_ADV", p_SIM_DEVICE="SPARTAN6",
-                                     p_BANDWIDTH="OPTIMIZED", p_COMPENSATION="INTERNAL",
-                                     p_REF_JITTER=.01, p_CLK_FEEDBACK="CLKFBOUT",
-                                     i_DADDR=0, i_DCLK=0, i_DEN=0, i_DI=0, i_DWE=0, i_RST=0, i_REL=0,
-                                     p_DIVCLK_DIVIDE=1, p_CLKFBOUT_MULT=m*p//n, p_CLKFBOUT_PHASE=0.,
-                                     i_CLKIN1=clk100b, i_CLKIN2=0, i_CLKINSEL=1,
-                                     p_CLKIN1_PERIOD=1e9/f0, p_CLKIN2_PERIOD=0.,
-                                     i_CLKFBIN=pll_fb, o_CLKFBOUT=pll_fb, o_LOCKED=pll_lckd,
-                                     o_CLKOUT0=pll[0], p_CLKOUT0_DUTY_CYCLE=.5,
-                                     o_CLKOUT1=pll[1], p_CLKOUT1_DUTY_CYCLE=.5,
-                                     o_CLKOUT2=pll[2], p_CLKOUT2_DUTY_CYCLE=.5,
-                                     o_CLKOUT3=pll[3], p_CLKOUT3_DUTY_CYCLE=.5,
-                                     o_CLKOUT4=pll[4], p_CLKOUT4_DUTY_CYCLE=.5,
-                                     o_CLKOUT5=pll[5], p_CLKOUT5_DUTY_CYCLE=.5,
-                                     p_CLKOUT0_PHASE=0., p_CLKOUT0_DIVIDE=p//4,  # sdram wr rd
-                                     p_CLKOUT1_PHASE=0., p_CLKOUT1_DIVIDE=p//4,
-                                     p_CLKOUT2_PHASE=270., p_CLKOUT2_DIVIDE=p//2,  # sdram dqs adr ctrl
-                                     p_CLKOUT3_PHASE=250., p_CLKOUT3_DIVIDE=p//2,  # off-chip ddr
-                                     p_CLKOUT4_PHASE=0., p_CLKOUT4_DIVIDE=p//1,
-                                     p_CLKOUT5_PHASE=0., p_CLKOUT5_DIVIDE=p//1,  # sys
+
+        unbuffered_sdram_full = Signal()
+        unbuffered_sdram_half_a = Signal()
+        unbuffered_sdram_half_b = Signal()
+        unbuffered_encoder = Signal()
+        unbuffered_sys = Signal()
+        unbuffered_base50 = Signal()
+
+        self.specials.pll = Instance(
+            "PLL_ADV",
+            p_SIM_DEVICE="SPARTAN6", p_BANDWIDTH="OPTIMIZED", p_COMPENSATION="INTERNAL",
+            p_REF_JITTER=.01,
+            i_DADDR=0, i_DCLK=0, i_DEN=0, i_DI=0, i_DWE=0, i_RST=0, i_REL=0,
+            p_DIVCLK_DIVIDE=1,
+            # Input Clocks (100MHz)
+            i_CLKIN1=clk100b,
+            p_CLKIN1_PERIOD=1e9/f0,
+            i_CLKIN2=0,
+            p_CLKIN2_PERIOD=0.,
+            i_CLKINSEL=1,
+            # Feedback
+            i_CLKFBIN=pll_fb, o_CLKFBOUT=pll_fb, o_LOCKED=pll_lckd,
+            p_CLK_FEEDBACK="CLKFBOUT",
+            p_CLKFBOUT_MULT=m*p//n, p_CLKFBOUT_PHASE=0.,
+            # (400MHz) sdram wr rd
+            o_CLKOUT0=unbuffered_sdram_full, p_CLKOUT0_DUTY_CYCLE=.5,
+            p_CLKOUT0_PHASE=0., p_CLKOUT0_DIVIDE=p//4,
+            # ( 66MHz) encoder
+            o_CLKOUT1=unbuffered_encoder, p_CLKOUT1_DUTY_CYCLE=.5,
+            p_CLKOUT1_PHASE=0., p_CLKOUT1_DIVIDE=6,
+            # (200MHz) sdram_half - sdram dqs adr ctrl
+            o_CLKOUT2=unbuffered_sdram_half_a, p_CLKOUT2_DUTY_CYCLE=.5,
+            p_CLKOUT2_PHASE=270., p_CLKOUT2_DIVIDE=p//2,
+            # (200MHz) off-chip ddr
+            o_CLKOUT3=unbuffered_sdram_half_b, p_CLKOUT3_DUTY_CYCLE=.5,
+            p_CLKOUT3_PHASE=250., p_CLKOUT3_DIVIDE=p//2,
+            # ( 50MHz) base50
+            o_CLKOUT4=unbuffered_base50, p_CLKOUT4_DUTY_CYCLE=.5,
+            p_CLKOUT4_PHASE=0., p_CLKOUT4_DIVIDE=p//1,
+            # ( 75MHz) sysclk
+            o_CLKOUT5=unbuffered_sys, p_CLKOUT5_DUTY_CYCLE=.5,
+            p_CLKOUT5_PHASE=0., p_CLKOUT5_DIVIDE=p//1.5,
         )
-        self.specials += Instance("BUFG", i_I=pll[5], o_O=self.cd_sys.clk)
+        # power on reset?
         reset = ~platform.request("cpu_reset")
         self.clock_domains.cd_por = ClockDomain()
         por = Signal(max=1 << 11, reset=(1 << 11) - 1)
         self.sync.por += If(por != 0, por.eq(por - 1))
-        self.comb += self.cd_por.clk.eq(self.cd_sys.clk)
         self.specials += AsyncResetSynchronizer(self.cd_por, reset)
+
+        # sys
+        self.specials += Instance("BUFG", i_I=unbuffered_sys, o_O=self.cd_sys.clk)
+        self.comb += self.cd_por.clk.eq(self.cd_sys.clk)
         self.specials += AsyncResetSynchronizer(self.cd_sys, ~pll_lckd | (por > 0))
-        self.specials += Instance("BUFG", i_I=pll[2], o_O=self.cd_sdram_half.clk)
+
+        # base50
+        self.specials += Instance("BUFG", i_I=unbuffered_base50, o_O=self.cd_base50.clk)
+
+        # encoder
+        self.specials += Instance("BUFG", i_I=unbuffered_encoder, o_O=self.cd_encoder.clk) # 66 MHz
+        self.specials += AsyncResetSynchronizer(self.cd_encoder, self.cd_sys.rst)
+
+        # SDRAM clocks
+        # ------------------------------------------------------------------------------
+        # sdram_full
         self.specials += Instance("BUFPLL", p_DIVIDE=4,
-                                  i_PLLIN=pll[0], i_GCLK=self.cd_sys.clk,
+                                  i_PLLIN=unbuffered_sdram_full, i_GCLK=self.cd_sys.clk,
                                   i_LOCKED=pll_lckd, o_IOCLK=self.cd_sdram_full_wr.clk,
                                   o_SERDESSTROBE=self.clk4x_wr_strb)
         self.comb += [
             self.cd_sdram_full_rd.clk.eq(self.cd_sdram_full_wr.clk),
             self.clk4x_rd_strb.eq(self.clk4x_wr_strb),
         ]
+        # sdram_half
+        self.specials += Instance("BUFG", i_I=unbuffered_sdram_half_a, o_O=self.cd_sdram_half.clk)
         clk_sdram_half_shifted = Signal()
-        self.specials += Instance("BUFG", i_I=pll[3], o_O=clk_sdram_half_shifted)
+        self.specials += Instance("BUFG", i_I=unbuffered_sdram_half_b, o_O=clk_sdram_half_shifted)
 
         output_clk = Signal()
         clk = platform.request("ddram_clock")
@@ -104,20 +145,15 @@ class _CRG(Module):
                                   o_Q=output_clk)
         self.specials += Instance("OBUFDS", i_I=output_clk, o_O=clk.p, o_OB=clk.n)
 
-
-        dcm_base50_locked = Signal()
-        self.specials += Instance("DCM_CLKGEN",
-                                  p_CLKFXDV_DIVIDE=2, p_CLKFX_DIVIDE=4, p_CLKFX_MD_MAX=1.0, p_CLKFX_MULTIPLY=2,
-                                  p_CLKIN_PERIOD=10.0, p_SPREAD_SPECTRUM="NONE", p_STARTUP_WAIT="FALSE",
-
-                                  i_CLKIN=clk100a, o_CLKFX=self.cd_base50.clk,
-                                  o_LOCKED=dcm_base50_locked,
-                                  i_FREEZEDCM=0, i_RST=ResetSignal())
-        self.specials += AsyncResetSynchronizer(self.cd_base50, self.cd_sys.rst | ~dcm_base50_locked)
-        platform.add_period_constraint(self.cd_base50.clk, 20)
-
-        self.comb += self.cd_encoder.clk.eq(self.cd_sys.clk)
-        self.specials += AsyncResetSynchronizer(self.cd_encoder, self.cd_sys.rst)
+        #dcm_base50_locked = Signal()
+        #self.specials += Instance("DCM_CLKGEN",
+        #                          p_CLKFXDV_DIVIDE=2, p_CLKFX_DIVIDE=4, p_CLKFX_MD_MAX=1.0, p_CLKFX_MULTIPLY=2,
+        #                          p_CLKIN_PERIOD=10.0, p_SPREAD_SPECTRUM="NONE", p_STARTUP_WAIT="FALSE",
+        #
+        #                          i_CLKIN=clk100a, o_CLKFX=self.cd_base50.clk,
+        #                          o_LOCKED=dcm_base50_locked,
+        #                          i_FREEZEDCM=0, i_RST=ResetSignal())
+        #self.specials += AsyncResetSynchronizer(self.cd_base50, self.cd_sys.rst | ~dcm_base50_locked)
 
 
 class BaseSoC(SDRAMSoC):
@@ -158,11 +194,13 @@ class BaseSoC(SDRAMSoC):
         self.add_constant("ROM_BOOT_ADDRESS", self.mem_map["firmware_ram"])
 
         if not self.integrated_main_ram_size:
-            self.submodules.ddrphy = s6ddrphy.S6HalfRateDDRPHY(platform.request("ddram"),
-                                                               P3R1GE4JGF(self.clk_freq),
-                                                               rd_bitslip=0,
-                                                               wr_bitslip=4,
-                                                               dqs_ddr_alignment="C0")
+            self.submodules.ddrphy = s6ddrphy.S6HalfRateDDRPHY(
+                platform.request("ddram"),
+                P3R1GE4JGF(self.clk_freq),
+                rd_bitslip=0,
+                wr_bitslip=4,
+                dqs_ddr_alignment="C0",
+            )
             self.comb += [
                 self.ddrphy.clk4x_wr_strb.eq(self.crg.clk4x_wr_strb),
                 self.ddrphy.clk4x_rd_strb.eq(self.crg.clk4x_rd_strb),
@@ -177,9 +215,17 @@ class BaseSoC(SDRAMSoC):
         self.register_mem("spiflash", self.mem_map["spiflash"], self.spiflash.bus, size=platform.gateware_size)
 
         self.specials += Keep(self.crg.cd_sys.clk)
+        self.specials += Keep(self.crg.cd_base50.clk)
         platform.add_platform_command("""
-NET "{sys_clk}" TNM_NET = "GRPsys_clk";
-""", sys_clk=self.crg.cd_sys.clk)
+# Separate TMNs for FROM:TO TIG constraints
+NET "{sys_clk}" TNM_NET = "TIGsys_clk";
+NET "{base50_clk}" TNM_NET = "TIGbase50_clk";
+""",
+            sys_clk=self.crg.cd_sys.clk,
+            base50_clk=self.crg.cd_base50.clk,
+        )
+        platform.add_period_constraint(self.crg.cd_sys.clk, math.floor(1e9/clk_freq))
+        platform.add_period_constraint(self.crg.cd_base50.clk, 20) # 50 MHz
 
 
 class MiniSoC(BaseSoC):
@@ -207,16 +253,21 @@ class MiniSoC(BaseSoC):
         self.add_wb_slave(mem_decoder(self.mem_map["ethmac"]), self.ethmac.bus)
         self.add_memory_region("ethmac", self.mem_map["ethmac"]+self.shadow_base, 0x2000)
 
+        self.specials += [
+            Keep(self.ethphy.crg.cd_eth_rx.clk),
+            Keep(self.ethphy.crg.cd_eth_tx.clk)
+        ]
         platform.add_platform_command("""
+# Separate TMNs for FROM:TO TIG constraints
 NET "{eth_clocks_rx}" CLOCK_DEDICATED_ROUTE = FALSE;
-NET "{eth_clocks_rx}" TNM_NET = "GRPeth_rx_clk";
-NET "{eth_clocks_tx}" TNM_NET = "GRPeth_tx_clk";
-TIMESPEC "TSise_sucks1" = FROM "GRPeth_tx_clk" TO "GRPsys_clk" TIG;
-TIMESPEC "TSise_sucks2" = FROM "GRPsys_clk" TO "GRPeth_tx_clk" TIG;
-TIMESPEC "TSise_sucks3" = FROM "GRPeth_rx_clk" TO "GRPsys_clk" TIG;
-TIMESPEC "TSise_sucks4" = FROM "GRPsys_clk" TO "GRPeth_rx_clk" TIG;
+NET "{eth_rx_clk}" TNM_NET = "TIGeth_rx_clk";
+NET "{eth_tx_clk}" TNM_NET = "TIGeth_tx_clk";
+TIMESPEC "TSeth_tx_to_sys" = FROM "TIGeth_tx_clk" TO "TIGsys_clk" TIG;
+TIMESPEC "TSsys_to_eth_tx" = FROM "TIGsys_clk" TO "TIGeth_tx_clk" TIG;
+TIMESPEC "TSeth_rx_to_sys" = FROM "TIGeth_rx_clk" TO "TIGsys_clk" TIG;
+TIMESPEC "TSsys_to_eth_rx" = FROM "TIGsys_clk" TO "TIGeth_rx_clk" TIG;
 """, eth_clocks_rx=platform.lookup_request("eth_clocks").rx,
-     eth_clocks_tx=platform.lookup_request("eth_clocks").tx)
-
+     eth_rx_clk=self.ethphy.crg.cd_eth_rx.clk,
+     eth_tx_clk=self.ethphy.crg.cd_eth_tx.clk)
 
 default_subtarget = MiniSoC

--- a/targets/atlys_hdmi2eth.py
+++ b/targets/atlys_hdmi2eth.py
@@ -21,7 +21,6 @@ from targets.common import *
 from targets.atlys_base import BaseSoC
 from targets.atlys_video import CreateVideoMixerSoC
 
-
 class EtherboneSoC(BaseSoC):
     csr_peripherals = (
         "ethphy",
@@ -50,25 +49,35 @@ class EtherboneSoC(BaseSoC):
             Keep(self.ethphy.crg.cd_eth_tx.clk)
         ]
         platform.add_platform_command("""
+# Separate TMNs for FROM:TO TIG constraints
 NET "{eth_clocks_rx}" CLOCK_DEDICATED_ROUTE = FALSE;
-NET "{eth_clocks_rx}" TNM_NET = "GRPeth_clocks_rx";
-NET "{eth_rx_clk}" TNM_NET = "GRPeth_rx_clk";
-NET "{eth_tx_clk}" TNM_NET = "GRPeth_tx_clk";
-TIMESPEC "TSise_sucks1" = FROM "GRPeth_clocks_rx" TO "GRPsys_clk" TIG;
-TIMESPEC "TSise_sucks2" = FROM "GRPsys_clk" TO "GRPeth_clocks_rx" TIG;
-TIMESPEC "TSise_sucks3" = FROM "GRPeth_tx_clk" TO "GRPsys_clk" TIG;
-TIMESPEC "TSise_sucks4" = FROM "GRPsys_clk" TO "GRPeth_tx_clk" TIG;
-TIMESPEC "TSise_sucks5" = FROM "GRPeth_rx_clk" TO "GRPsys_clk" TIG;
-TIMESPEC "TSise_sucks6" = FROM "GRPsys_clk" TO "GRPeth_rx_clk" TIG;
-""", eth_clocks_rx=platform.lookup_request("eth_clocks").rx,
-     eth_rx_clk=self.ethphy.crg.cd_eth_rx.clk,
-     eth_tx_clk=self.ethphy.crg.cd_eth_tx.clk)
+NET "{eth_clocks_rx}" TNM_NET = "TIGeth_clocks_rx";
+TIMESPEC "TSeth_clocks_rx_to_sys" = FROM "TIGeth_clocks_rx" TO "TIGsys_clk" TIG;
+TIMESPEC "TSsys_to_eth_clocks_rx" = FROM "TIGsys_clk" TO "TIGeth_clocks_rx" TIG;
+
+NET "{eth_clocks_tx}" TNM_NET = "TIGeth_clocks_tx";
+TIMESPEC "TSeth_clocks_tx_to_sys" = FROM "TIGeth_clocks_tx" TO "TIGsys_clk" TIG;
+TIMESPEC "TSsys_to_eth_clocks_tx" = FROM "TIGsys_clk" TO "TIGeth_clocks_tx" TIG;
+
+NET "{eth_rx_clk}" TNM_NET = "TIGeth_rx_clk";
+TIMESPEC "TSeth_rx_to_sys" = FROM "TIGeth_rx_clk" TO "TIGsys_clk" TIG;
+TIMESPEC "TSsys_to_eth_rx" = FROM "TIGsys_clk" TO "TIGeth_rx_clk" TIG;
+
+NET "{eth_tx_clk}" TNM_NET = "TIGeth_tx_clk";
+TIMESPEC "TSeth_tx_to_sys" = FROM "TIGeth_tx_clk" TO "TIGsys_clk" TIG;
+TIMESPEC "TSsys_to_eth_tx" = FROM "TIGsys_clk" TO "TIGeth_tx_clk" TIG;
+""",
+            eth_clocks_rx=platform.lookup_request("eth_clocks").rx,
+            eth_clocks_tx=platform.lookup_request("eth_clocks").tx,
+            eth_rx_clk=self.ethphy.crg.cd_eth_rx.clk,
+            eth_tx_clk=self.ethphy.crg.cd_eth_tx.clk,
+        )
 
 
 EtherVideoMixerSoC = CreateVideoMixerSoC(EtherboneSoC)
 
 
-class HDMI2EthSoC(EtherVideoMixerSoC):
+class HDMI2ETHSoC(EtherVideoMixerSoC):
     csr_peripherals = (
         "encoder_reader",
         "encoder",

--- a/targets/atlys_hdmi2eth.py
+++ b/targets/atlys_hdmi2eth.py
@@ -38,7 +38,7 @@ class EtherboneSoC(BaseSoC):
 
         # Ethernet PHY and UDP/IP stack
         self.submodules.ethphy = LiteEthPHYMII(platform.request("eth_clocks"), platform.request("eth"))
-        self.submodules.ethcore = LiteEthUDPIPCore(self.ethphy, mac_address, convert_ip(ip_address), self.clk_freq, with_icmp=False)
+        self.submodules.ethcore = LiteEthUDPIPCore(self.ethphy, mac_address, convert_ip(ip_address), int(self.clk_freq), with_icmp=False)
 
         # Etherbone bridge
         self.submodules.etherbone = LiteEthEtherbone(self.ethcore.udp, 20000)

--- a/targets/atlys_hdmi2eth.py
+++ b/targets/atlys_hdmi2eth.py
@@ -77,7 +77,7 @@ TIMESPEC "TSsys_to_eth_tx" = FROM "TIGsys_clk" TO "TIGeth_tx_clk" TIG;
 EtherVideoMixerSoC = CreateVideoMixerSoC(EtherboneSoC)
 
 
-class HDMI2ETHSoC(EtherVideoMixerSoC):
+class HDMI2EthSoC(EtherVideoMixerSoC):
     csr_peripherals = (
         "encoder_reader",
         "encoder",

--- a/targets/atlys_hdmi2usb.py
+++ b/targets/atlys_hdmi2usb.py
@@ -48,9 +48,10 @@ class HDMI2USBSoC(VideoMixerSoC):
         self.add_memory_region("encoder", self.mem_map["encoder"]+self.shadow_base, 0x2000)
 
         platform.add_platform_command("""
-NET "{usb_clk}" TNM_NET = "GRPusb_clk";
-TIMESPEC "TSise_sucks11" = FROM "GRPusb_clk" TO "GRPsys_clk" TIG;
-TIMESPEC "TSise_sucks12" = FROM "GRPsys_clk" TO "GRPusb_clk" TIG;
+# Separate TMNs for FROM:TO TIG constraints
+NET "{usb_clk}" TNM_NET = "TIGusb_clk";
+TIMESPEC "TSusb_to_sys" = FROM "TIGusb_clk" TO "TIGsys_clk" TIG;
+TIMESPEC "TSsys_to_usb" = FROM "TIGsys_clk" TO "TIGusb_clk" TIG;
 """, usb_clk=platform.lookup_request("fx2").ifclk)
 
 

--- a/targets/atlys_hdmi2usb.py
+++ b/targets/atlys_hdmi2usb.py
@@ -52,7 +52,10 @@ class HDMI2USBSoC(VideoMixerSoC):
 NET "{usb_clk}" TNM_NET = "TIGusb_clk";
 TIMESPEC "TSusb_to_sys" = FROM "TIGusb_clk" TO "TIGsys_clk" TIG;
 TIMESPEC "TSsys_to_usb" = FROM "TIGsys_clk" TO "TIGusb_clk" TIG;
-""", usb_clk=platform.lookup_request("fx2").ifclk)
+""",
+            usb_clk=platform.lookup_request("fx2").ifclk,
+        )
+
 
 
 default_subtarget = HDMI2USBSoC

--- a/targets/atlys_video.py
+++ b/targets/atlys_video.py
@@ -52,12 +52,13 @@ def CreateVideoMixerSoC(base):
                 """PIN "hdmi_out_pix_bufg_1.O" CLOCK_DEDICATED_ROUTE = FALSE;""")
             platform.add_platform_command(
                 """
-NET "{pix0_clk}" TNM_NET = "GRPpix0_clk";
-NET "{pix1_clk}" TNM_NET = "GRPpix1_clk";
-TIMESPEC "TSise_sucks7" = FROM "GRPpix0_clk" TO "GRPsys_clk" TIG;
-TIMESPEC "TSise_sucks8" = FROM "GRPsys_clk" TO "GRPpix0_clk" TIG;
-TIMESPEC "TSise_sucks9" = FROM "GRPpix1_clk" TO "GRPsys_clk" TIG;
-TIMESPEC "TSise_sucks10" = FROM "GRPsys_clk" TO "GRPpix1_clk" TIG;
+# Separate TMNs for FROM:TO TIG constraints
+NET "{pix0_clk}" TNM_NET = "TIGpix0_clk";
+NET "{pix1_clk}" TNM_NET = "TIGpix1_clk";
+TIMESPEC "TSpix0_to_sys" = FROM "TIGpix0_clk" TO "TIGsys_clk"  TIG;
+TIMESPEC "TSsys_to_pix0" = FROM "TIGsys_clk"  TO "TIGpix0_clk" TIG;
+TIMESPEC "TSpix1_to_sys" = FROM "TIGpix1_clk" TO "TIGsys_clk"  TIG;
+TIMESPEC "TSsys_to_pix1" = FROM "TIGsys_clk"  TO "TIGpix1_clk" TIG;
 """, 
                 pix0_clk=self.hdmi_out0.driver.clocking.cd_pix.clk,
                 pix1_clk=self.hdmi_out1.driver.clocking.cd_pix.clk,

--- a/targets/common.py
+++ b/targets/common.py
@@ -2,5 +2,48 @@ import os
 import struct
 
 def csr_map_update(csr_map, csr_peripherals):
-  csr_map.update(dict((n, v) for v, n in enumerate(csr_peripherals, start=max(csr_map.values()) + 1)))
+    csr_map.update(dict((n, v) for v, n in enumerate(csr_peripherals, start=max(csr_map.values()) + 1)))
 
+def assert_pll_clock(requested_freq, input, feedback, divide, msg):
+    output_freq = int(input * feedback / divide / 1e6)
+    assert output_freq == int(requested_freq / 1e6), (
+        "%s wants %s but got %i MHz (input=%i MHz feedback=%i divide=%i)" % (
+            msg, requested_freq, output_freq, int(input/1e6), feedback, divide))
+
+
+class MHzType(int):
+    """
+    >>> a = MHzType(1)
+    >>> a == int(1e9)
+    True
+    >>> a
+    1 MHz
+    >>> b = 5 * MHzType(1)
+    >>> b == int(5e9)
+    True
+    >>> b
+    5 MHz
+    >>> c = 200 * MHzType(1)
+    >>>
+    """
+
+    def __new__(cls, x):
+        return int.__new__(cls, int(x * 1e6))
+
+    def __str__(self):
+        return "%i MHz" % int(self / 1e6)
+
+    def __repr__(self):
+        return "%f * MHz()" % float(self / 1e6)
+
+    def __mul__(self, o):
+        return MHz.__class__(float(self) * o / 1e6)
+
+    def __rmul__(self, o):
+        return MHz.__class__(float(self) * o / 1e6)
+
+    def to_ns(self):
+        return 1e9/self
+
+
+MHz = MHzType(1)

--- a/targets/minispartan6_video.py
+++ b/targets/minispartan6_video.py
@@ -1,3 +1,5 @@
+from migen.fhdl.std import ClockSignal
+
 from gateware.hdmi_in import HDMIIn
 from gateware.hdmi_out import HDMIOut
 
@@ -26,7 +28,8 @@ class VideoMixerSoC(BaseSoC):
 #            fifo_depth=1024)
         self.submodules.hdmi_out0 = HDMIOut(
             platform.request("hdmi_out", 0),
-            self.sdram.crossbar.get_master())
+            self.sdram.crossbar.get_master(),
+            clock50=ClockSignal(self.crg.cd_base50.name))
 
         # FIXME: Fix the HDMI out so this can be removed.
         platform.add_platform_command(

--- a/targets/opsis_base.py
+++ b/targets/opsis_base.py
@@ -19,6 +19,7 @@ from misoclib.soc.sdram import SDRAMSoC
 from misoclib.com.uart.phy import UARTPHY
 from misoclib.com import uart
 
+from liteeth.common import *
 from liteeth.phy.s6rgmii import LiteEthPHYRGMII
 from liteeth.core.mac import LiteEthMAC
 
@@ -217,7 +218,6 @@ class BaseSoC(SDRAMSoC):
         self.submodules.git_info = git_info.GitInfo()
         self.submodules.platform_info = platform_info.PlatformInfo("opsis", self.__class__.__name__[:8])
 
-
         fx2_uart_pads = platform.request("serial_fx2")
         sd_card_uart_pads = platform.request("serial_sd_card")
         uart_pads = UARTSharedPads()
@@ -242,11 +242,13 @@ class BaseSoC(SDRAMSoC):
         self.add_constant("ROM_BOOT_ADDRESS", self.mem_map["firmware_ram"])
 
         if not self.integrated_main_ram_size:
-            self.submodules.ddrphy = s6ddrphy.S6QuarterRateDDRPHY(platform.request("ddram"),
-                                                                  MT41J128M16(self.clk_freq),
-                                                                  rd_bitslip=0,
-                                                                  wr_bitslip=4,
-                                                                  dqs_ddr_alignment="C0")
+            self.submodules.ddrphy = s6ddrphy.S6QuarterRateDDRPHY(
+                platform.request("ddram"),
+                MT41J128M16(self.clk_freq),
+                rd_bitslip=0,
+                wr_bitslip=4,
+                dqs_ddr_alignment="C0",
+            )
             self.comb += [
                 self.ddrphy.clk8x_wr_strb.eq(self.crg.clk8x_wr_strb),
                 self.ddrphy.clk8x_rd_strb.eq(self.crg.clk8x_rd_strb),

--- a/targets/opsis_base.py
+++ b/targets/opsis_base.py
@@ -272,11 +272,11 @@ NET "{sys_clk}" TNM_NET = "TIGsys_clk";
 NET "{periph_clk}" TNM_NET = "TIGperiph_clk";
 NET "{encoder_clk}" TNM_NET = "TIGencoder_clk";
 
-TIMESPECT "TSsys_to_periph" = FROM "TIGsys_clk" TO "TIGperiph_clk" TIG;
-TIMESPECT "TSperiph_to_sys" = FROM "TIGsys_periph" TO "TIGsys_clk" TIG;
+TIMESPEC "TSsys_to_periph" = FROM "TIGsys_clk" TO "TIGperiph_clk" TIG;
+TIMESPEC "TSperiph_to_sys" = FROM "TIGperiph_clk" TO "TIGsys_clk" TIG;
 
-TIMESPECT "TSsys_to_encoder" = FROM "TIGsys_clk" TO "TIGencoder_clk" TIG;
-TIMESPECT "TSencoder_to_sys" = FROM "TIGsys_encoder" TO "TIGsys_clk" TIG;
+TIMESPEC "TSsys_to_encoder" = FROM "TIGsys_clk" TO "TIGencoder_clk" TIG;
+TIMESPEC "TSencoder_to_sys" = FROM "TIGencoder_clk" TO "TIGsys_clk" TIG;
 """,
             sys_clk=self.crg.cd_sys.clk,
             periph_clk=self.crg.cd_periph.clk,

--- a/targets/opsis_base.py
+++ b/targets/opsis_base.py
@@ -267,7 +267,7 @@ class BaseSoC(SDRAMSoC):
         platform.add_platform_command("""
 # Separate TMNs for FROM:TO TIG constraints
 NET "{sys_clk}" TNM_NET = "TIGsys_clk";
-NET "{base50_clk}" TNM_NET = "TIGbase50_clk";
+#NET "{base50_clk}" TNM_NET = "TIGbase50_clk";
 """,
             sys_clk=self.crg.cd_sys.clk,
             base50_clk=self.crg.cd_base50.clk,

--- a/targets/opsis_base.py
+++ b/targets/opsis_base.py
@@ -35,19 +35,20 @@ from targets.common import *
 
 class _CRG(Module):
     def __init__(self, platform, clk_freq):
+        # Clock domains for the system (soft CPU and related components run at).
         self.clock_domains.cd_sys = ClockDomain()
         self.clock_domains.cd_sys2x = ClockDomain()
+        # Clock domains for the DDR interface.
         self.clock_domains.cd_sdram_half = ClockDomain()
         self.clock_domains.cd_sdram_full_wr = ClockDomain()
         self.clock_domains.cd_sdram_full_rd = ClockDomain()
-        self.clock_domains.cd_base50 = ClockDomain()
+        # Clock domain for peripherals (such as HDMI output).
+        self.clock_domains.cd_periph = ClockDomain()
+        # Clock domain for the JPEG Encoder.
         self.clock_domains.cd_encoder = ClockDomain()
 
-        self.clk8x_wr_strb = Signal()
-        self.clk8x_rd_strb = Signal()
-
         # Input 100MHz clock
-        f0 = 100*1000000
+        f0 = 100 * MHz
         clk100 = platform.request("clk100")
         clk100a = Signal()
         # Input 100MHz clock (buffered)
@@ -62,9 +63,9 @@ class _CRG(Module):
         n, m = f.denominator, f.numerator
         assert f0/n*m == clk_freq
         p = 8
-        pll_lckd = Signal()
-        pll_fb = Signal()
 
+        # Unbuffered output signals from the PLL. They need to be buffered
+        # before feeding into the fabric.
         unbuf_sdram_full = Signal()
         unbuf_sdram_half_a = Signal()
         unbuf_sdram_half_b = Signal()
@@ -72,6 +73,9 @@ class _CRG(Module):
         unbuf_sys = Signal()
         unbuf_sys2x = Signal()
 
+        # PLL signals
+        pll_lckd = Signal()
+        pll_fb = Signal()
         self.specials.pll = Instance(
             "PLL_ADV",
             p_SIM_DEVICE="SPARTAN6", p_BANDWIDTH="OPTIMIZED", p_COMPENSATION="INTERNAL",
@@ -88,25 +92,33 @@ class _CRG(Module):
             i_CLKFBIN=pll_fb, o_CLKFBOUT=pll_fb, o_LOCKED=pll_lckd,
             p_CLK_FEEDBACK="CLKFBOUT",
             p_CLKFBOUT_MULT=m*p//n, p_CLKFBOUT_PHASE=0.,
-            # (800MHz) sdram wr rd
+            # (400MHz) sdram wr rd
             o_CLKOUT0=unbuf_sdram_full, p_CLKOUT0_DUTY_CYCLE=.5,
             p_CLKOUT0_PHASE=0., p_CLKOUT0_DIVIDE=p//8,
             # ( 66MHz) encoder
             o_CLKOUT1=unbuf_encoder, p_CLKOUT1_DUTY_CYCLE=.5,
             p_CLKOUT1_PHASE=0., p_CLKOUT1_DIVIDE=6,
-            # (400MHz) sdram_half - sdram dqs adr ctrl
+            # (200MHz) sdram_half - sdram dqs adr ctrl
             o_CLKOUT2=unbuf_sdram_half_a, p_CLKOUT2_DUTY_CYCLE=.5,
             p_CLKOUT2_PHASE=230., p_CLKOUT2_DIVIDE=p//4,
-            # (400MHz) off-chip ddr
+            # (200MHz) off-chip ddr
             o_CLKOUT3=unbuf_sdram_half_b, p_CLKOUT3_DUTY_CYCLE=.5,
             p_CLKOUT3_PHASE=210., p_CLKOUT3_DIVIDE=p//4,
             # (100MHz) sys2x
             o_CLKOUT4=unbuf_sys2x, p_CLKOUT4_DUTY_CYCLE=.5,
             p_CLKOUT4_PHASE=0., p_CLKOUT4_DIVIDE=p//2,
-            # ( 50MHz) base50 / sys
+            # ( 50MHz) periph / sys
             o_CLKOUT5=unbuf_sys, p_CLKOUT5_DUTY_CYCLE=.5,
             p_CLKOUT5_PHASE=0., p_CLKOUT5_DIVIDE=p//1,
         )
+
+        # assert the clocks turned out as requested.
+        assert_pll_clock(400 * MHz, input=f0, feedback=(m*p//n), divide=(p//8), msg="CLKOUT0")
+        assert_pll_clock( 66 * MHz, input=f0, feedback=(m*p//n), divide=(6   ), msg="CLKOUT1")
+        assert_pll_clock(200 * MHz, input=f0, feedback=(m*p//n), divide=(p//4), msg="CLKOUT2 && CLKOUT3")
+        assert_pll_clock(100 * MHz, input=f0, feedback=(m*p//n), divide=(p//2), msg="CLKOUT4")
+        assert_pll_clock( 50 * MHz, input=f0, feedback=(m*p//n), divide=(p//1), msg="CLKOUT5")
+
         # power on reset?
         reset = ~platform.request("cpu_reset")
         self.clock_domains.cd_por = ClockDomain()
@@ -114,24 +126,32 @@ class _CRG(Module):
         self.sync.por += If(por != 0, por.eq(por - 1))
         self.specials += AsyncResetSynchronizer(self.cd_por, reset)
 
-        # sys
+        # System clock - 50MHz
         self.specials += Instance("BUFG", i_I=unbuf_sys, o_O=self.cd_sys.clk)
         self.comb += self.cd_por.clk.eq(self.cd_sys.clk)
         self.specials += AsyncResetSynchronizer(self.cd_sys, ~pll_lckd | (por > 0))
-
-        # base50
-        self.specials += Instance("BUFG", i_I=unbuf_sys, o_O=self.cd_base50.clk)
 
         # sys2x
         self.specials += Instance("BUFG", i_I=unbuf_sys2x, o_O=self.cd_sys2x.clk)
         self.specials += AsyncResetSynchronizer(self.cd_sys2x, ~pll_lckd | (por > 0))
 
-        # encoder
-        self.specials += Instance("BUFG", i_I=unbuf_encoder, o_O=self.cd_encoder.clk) # 66 MHz
+        # Peripheral clock - 50MHz
+        # The peripheral clock is kept separate from the system clock to allow
+        # the system clock to be increased in the future.
+        self.specials += Instance("BUFG", i_I=unbuf_sys, o_O=self.cd_periph.clk)
+        self.specials += AsyncResetSynchronizer(self.cd_periph, self.cd_sys.rst)
+
+        # JPEG encoder clock - 66MHz
+        # The JPEG encoder has it's own clock as we want it to run at higher
+        # speed then the other peripherals.
+        self.specials += Instance("BUFG", i_I=unbuf_encoder, o_O=self.cd_encoder.clk)
         self.specials += AsyncResetSynchronizer(self.cd_encoder, self.cd_sys.rst)
 
         # SDRAM clocks
         # ------------------------------------------------------------------------------
+        self.clk8x_wr_strb = Signal()
+        self.clk8x_rd_strb = Signal()
+
         # sdram_full
         self.specials += Instance("BUFPLL", p_DIVIDE=4,
                                   i_PLLIN=unbuf_sdram_full, i_GCLK=self.cd_sys2x.clk,
@@ -154,24 +174,6 @@ class _CRG(Module):
                                   i_C0=clk_sdram_half_shifted, i_C1=~clk_sdram_half_shifted,
                                   o_Q=output_clk)
         self.specials += Instance("OBUFDS", i_I=output_clk, o_O=clk.p, o_OB=clk.n)
-
-        #dcm_base50_locked = Signal()
-        #
-        #   i_CLKIN = 100MHz
-        #   o_CLKFX = 50MHz
-        # o_CLKFXDV = ???
-        #    FCLKFX = FCLKIN * (CLKFX_MULTIPLY / CLKFX_DIVIDE)
-        #     50MHz = 100MHz * (2              / 4)
-        #  FCLKFXDV = FCLKFX / CLKFXDV_DIVIDE
-        #     25MHz =  50MHz / 2
-        #self.specials += Instance("DCM_CLKGEN",
-        #                          p_CLKFXDV_DIVIDE=2, p_CLKFX_DIVIDE=4, p_CLKFX_MD_MAX=1.0, p_CLKFX_MULTIPLY=2,
-        #                          p_CLKIN_PERIOD=10.0, p_SPREAD_SPECTRUM="NONE", p_STARTUP_WAIT="FALSE",
-        #
-        #                          i_CLKIN=clk100a, o_CLKFX=self.cd_base50.clk,
-        #                          o_LOCKED=dcm_base50_locked,
-        #                          i_FREEZEDCM=0, i_RST=ResetSignal())
-        #self.specials += AsyncResetSynchronizer(self.cd_base50, self.cd_sys.rst | ~dcm_base50_locked)
 
 
 
@@ -206,7 +208,7 @@ class BaseSoC(SDRAMSoC):
                  firmware_ram_size=0x10000,
                  firmware_filename=None,
                  **kwargs):
-        clk_freq = 50*1000000
+        clk_freq = 50 * MHz
         SDRAMSoC.__init__(self, platform, clk_freq,
                           integrated_rom_size=0x8000,
                           sdram_controller_settings=LASMIconSettings(l2_size=32, with_bandwidth=True),
@@ -263,19 +265,27 @@ class BaseSoC(SDRAMSoC):
         self.register_mem("spiflash", self.mem_map["spiflash"], self.spiflash.bus, size=platform.gateware_size)
 
         self.specials += Keep(self.crg.cd_sys.clk)
-        self.specials += Keep(self.crg.cd_base50.clk)
+        self.specials += Keep(self.crg.cd_periph.clk)
         platform.add_platform_command("""
 # Separate TMNs for FROM:TO TIG constraints
 NET "{sys_clk}" TNM_NET = "TIGsys_clk";
-#NET "{base50_clk}" TNM_NET = "TIGbase50_clk";
+NET "{periph_clk}" TNM_NET = "TIGperiph_clk";
+NET "{encoder_clk}" TNM_NET = "TIGencoder_clk";
+
+TIMESPECT "TSsys_to_periph" = FROM "TIGsys_clk" TO "TIGperiph_clk" TIG;
+TIMESPECT "TSperiph_to_sys" = FROM "TIGsys_periph" TO "TIGsys_clk" TIG;
+
+TIMESPECT "TSsys_to_encoder" = FROM "TIGsys_clk" TO "TIGencoder_clk" TIG;
+TIMESPECT "TSencoder_to_sys" = FROM "TIGsys_encoder" TO "TIGsys_clk" TIG;
 """,
             sys_clk=self.crg.cd_sys.clk,
-            base50_clk=self.crg.cd_base50.clk,
+            periph_clk=self.crg.cd_periph.clk,
+            encoder_clk=self.crg.cd_encoder.clk,
         )
         # These constraints are unneeded because ISE will trace through the PLL
         # block and calculate them.
-        #platform.add_period_constraint(self.crg.cd_sys.clk, math.floor(1e9/clk_freq))
-        #platform.add_period_constraint(self.crg.cd_base50.clk, math.floor(1e9/clk_freq))
+        #platform.add_period_constraint(self.crg.cd_sys.clk, 20) # 20ns == 50 MHz
+        #platform.add_period_constraint(self.crg.cd_periph.clk, 20) # 20ns == 50 MHz
 
 
 class MiniSoC(BaseSoC):

--- a/targets/opsis_base.py
+++ b/targets/opsis_base.py
@@ -261,9 +261,16 @@ class BaseSoC(SDRAMSoC):
         self.register_mem("spiflash", self.mem_map["spiflash"], self.spiflash.bus, size=platform.gateware_size)
 
         self.specials += Keep(self.crg.cd_sys.clk)
-        platform.add_platform_command("""
-NET "{sys_clk}" TNM_NET = "GRPsys_clk";
-""", sys_clk=self.crg.cd_sys.clk)
+        self.specials += Keep(self.crg.cd_base50.clk)
+        platform.add_platform_command(
+            """
+NET "{sys_clk}" TNM_NET = "GRPsys_clk"; # Only used for PERIOD constraint
+NET "{sys_clk}" TNM_NET = "TIGsys_clk"; # Use for FROM:TO TIG constraints
+NET "{base50_clk}" TNM_NET = "GRPbase50_clk";
+""",
+            sys_clk=self.crg.cd_sys.clk,
+            base50_clk=self.crg.cd_base50.clk,
+        )
 
 
 class MiniSoC(BaseSoC):

--- a/targets/opsis_base.py
+++ b/targets/opsis_base.py
@@ -65,12 +65,12 @@ class _CRG(Module):
         pll_lckd = Signal()
         pll_fb = Signal()
 
-        unbuffered_sdram_full = Signal()
-        unbuffered_sdram_half_a = Signal()
-        unbuffered_sdram_half_b = Signal()
-        unbuffered_encoder = Signal()
-        unbuffered_sys = Signal()
-        unbuffered_sys2x = Signal()
+        unbuf_sdram_full = Signal()
+        unbuf_sdram_half_a = Signal()
+        unbuf_sdram_half_b = Signal()
+        unbuf_encoder = Signal()
+        unbuf_sys = Signal()
+        unbuf_sys2x = Signal()
 
         self.specials.pll = Instance(
             "PLL_ADV",
@@ -89,22 +89,22 @@ class _CRG(Module):
             p_CLK_FEEDBACK="CLKFBOUT",
             p_CLKFBOUT_MULT=m*p//n, p_CLKFBOUT_PHASE=0.,
             # (800MHz) sdram wr rd
-            o_CLKOUT0=unbuffered_sdram_full, p_CLKOUT0_DUTY_CYCLE=.5,
+            o_CLKOUT0=unbuf_sdram_full, p_CLKOUT0_DUTY_CYCLE=.5,
             p_CLKOUT0_PHASE=0., p_CLKOUT0_DIVIDE=p//8,
             # ( 66MHz) encoder
-            o_CLKOUT1=unbuffered_encoder, p_CLKOUT1_DUTY_CYCLE=.5,
+            o_CLKOUT1=unbuf_encoder, p_CLKOUT1_DUTY_CYCLE=.5,
             p_CLKOUT1_PHASE=0., p_CLKOUT1_DIVIDE=6,
             # (400MHz) sdram_half - sdram dqs adr ctrl
-            o_CLKOUT2=unbuffered_sdram_half_a, p_CLKOUT2_DUTY_CYCLE=.5,
+            o_CLKOUT2=unbuf_sdram_half_a, p_CLKOUT2_DUTY_CYCLE=.5,
             p_CLKOUT2_PHASE=230., p_CLKOUT2_DIVIDE=p//4,
             # (400MHz) off-chip ddr
-            o_CLKOUT3=unbuffered_sdram_half_b, p_CLKOUT3_DUTY_CYCLE=.5,
+            o_CLKOUT3=unbuf_sdram_half_b, p_CLKOUT3_DUTY_CYCLE=.5,
             p_CLKOUT3_PHASE=210., p_CLKOUT3_DIVIDE=p//4,
             # (100MHz) sys2x
-            o_CLKOUT4=unbuffered_sys2x, p_CLKOUT4_DUTY_CYCLE=.5,
+            o_CLKOUT4=unbuf_sys2x, p_CLKOUT4_DUTY_CYCLE=.5,
             p_CLKOUT4_PHASE=0., p_CLKOUT4_DIVIDE=p//2,
             # ( 50MHz) base50 / sys
-            o_CLKOUT5=unbuffered_sys, p_CLKOUT5_DUTY_CYCLE=.5,
+            o_CLKOUT5=unbuf_sys, p_CLKOUT5_DUTY_CYCLE=.5,
             p_CLKOUT5_PHASE=0., p_CLKOUT5_DIVIDE=p//1,
         )
         # power on reset?
@@ -115,26 +115,26 @@ class _CRG(Module):
         self.specials += AsyncResetSynchronizer(self.cd_por, reset)
 
         # sys
-        self.specials += Instance("BUFG", i_I=unbuffered_sys, o_O=self.cd_sys.clk)
+        self.specials += Instance("BUFG", i_I=unbuf_sys, o_O=self.cd_sys.clk)
         self.comb += self.cd_por.clk.eq(self.cd_sys.clk)
         self.specials += AsyncResetSynchronizer(self.cd_sys, ~pll_lckd | (por > 0))
 
         # base50
-        self.specials += Instance("BUFG", i_I=unbuffered_sys, o_O=self.cd_base50.clk)
+        self.specials += Instance("BUFG", i_I=unbuf_sys, o_O=self.cd_base50.clk)
 
         # sys2x
-        self.specials += Instance("BUFG", i_I=unbuffered_sys2x, o_O=self.cd_sys2x.clk)
+        self.specials += Instance("BUFG", i_I=unbuf_sys2x, o_O=self.cd_sys2x.clk)
         self.specials += AsyncResetSynchronizer(self.cd_sys2x, ~pll_lckd | (por > 0))
 
         # encoder
-        self.specials += Instance("BUFG", i_I=unbuffered_encoder, o_O=self.cd_encoder.clk) # 66 MHz
+        self.specials += Instance("BUFG", i_I=unbuf_encoder, o_O=self.cd_encoder.clk) # 66 MHz
         self.specials += AsyncResetSynchronizer(self.cd_encoder, self.cd_sys.rst)
 
         # SDRAM clocks
         # ------------------------------------------------------------------------------
         # sdram_full
         self.specials += Instance("BUFPLL", p_DIVIDE=4,
-                                  i_PLLIN=unbuffered_sdram_full, i_GCLK=self.cd_sys2x.clk,
+                                  i_PLLIN=unbuf_sdram_full, i_GCLK=self.cd_sys2x.clk,
                                   i_LOCKED=pll_lckd, o_IOCLK=self.cd_sdram_full_wr.clk,
                                   o_SERDESSTROBE=self.clk8x_wr_strb)
         self.comb += [
@@ -142,9 +142,9 @@ class _CRG(Module):
             self.clk8x_rd_strb.eq(self.clk8x_wr_strb),
         ]
         # sdram_half
-        self.specials += Instance("BUFG", i_I=unbuffered_sdram_half_a, o_O=self.cd_sdram_half.clk)
+        self.specials += Instance("BUFG", i_I=unbuf_sdram_half_a, o_O=self.cd_sdram_half.clk)
         clk_sdram_half_shifted = Signal()
-        self.specials += Instance("BUFG", i_I=unbuffered_sdram_half_b, o_O=clk_sdram_half_shifted)
+        self.specials += Instance("BUFG", i_I=unbuf_sdram_half_b, o_O=clk_sdram_half_shifted)
 
         output_clk = Signal()
         clk = platform.request("ddram_clock")

--- a/targets/opsis_base.py
+++ b/targets/opsis_base.py
@@ -272,8 +272,10 @@ NET "{base50_clk}" TNM_NET = "TIGbase50_clk";
             sys_clk=self.crg.cd_sys.clk,
             base50_clk=self.crg.cd_base50.clk,
         )
-        platform.add_period_constraint(self.crg.cd_sys.clk, math.floor(1e9/clk_freq))
-        platform.add_period_constraint(self.crg.cd_base50.clk, math.floor(1e9/clk_freq))
+        # These constraints are unneeded because ISE will trace through the PLL
+        # block and calculate them.
+        #platform.add_period_constraint(self.crg.cd_sys.clk, math.floor(1e9/clk_freq))
+        #platform.add_period_constraint(self.crg.cd_base50.clk, math.floor(1e9/clk_freq))
 
 
 class MiniSoC(BaseSoC):

--- a/targets/opsis_hdmi2usb.py
+++ b/targets/opsis_hdmi2usb.py
@@ -45,11 +45,11 @@ class HDMI2USBSoC(VideoMixerSoC):
         self.add_wb_slave(mem_decoder(self.mem_map["encoder"]), self.encoder.bus)
         self.add_memory_region("encoder", self.mem_map["encoder"]+self.shadow_base, 0x2000)
 
-        platform.add_platform_command("""
-NET "{usb_clk}" TNM_NET = "GRPusb_clk";
-TIMESPEC "TSise_sucks11" = FROM "GRPusb_clk" TO "GRPsys_clk" TIG;
-TIMESPEC "TSise_sucks12" = FROM "GRPsys_clk" TO "GRPusb_clk" TIG;
-""", usb_clk=platform.lookup_request("fx2").ifclk)
+#        platform.add_platform_command("""
+#NET "{usb_clk}" TNM_NET = "GRPusb_clk";
+#TIMESPEC "TSise_sucks11" = FROM "GRPusb_clk" TO "GRPsys_clk" TIG;
+#TIMESPEC "TSise_sucks12" = FROM "GRPsys_clk" TO "GRPusb_clk" TIG;
+#""", usb_clk=platform.lookup_request("fx2").ifclk)
 
 
 default_subtarget = HDMI2USBSoC

--- a/targets/opsis_hdmi2usb.py
+++ b/targets/opsis_hdmi2usb.py
@@ -50,7 +50,10 @@ class HDMI2USBSoC(VideoMixerSoC):
 NET "{usb_clk}" TNM_NET = "TIGusb_clk";
 TIMESPEC "TSusb_to_sys" = FROM "TIGusb_clk" TO "TIGsys_clk" TIG;
 TIMESPEC "TSsys_to_usb" = FROM "TIGsys_clk" TO "TIGusb_clk" TIG;
-""", usb_clk=platform.lookup_request("fx2").ifclk)
+""",
+            usb_clk=platform.lookup_request("fx2").ifclk,
+        )
+
 
 
 default_subtarget = HDMI2USBSoC

--- a/targets/opsis_hdmi2usb.py
+++ b/targets/opsis_hdmi2usb.py
@@ -45,11 +45,12 @@ class HDMI2USBSoC(VideoMixerSoC):
         self.add_wb_slave(mem_decoder(self.mem_map["encoder"]), self.encoder.bus)
         self.add_memory_region("encoder", self.mem_map["encoder"]+self.shadow_base, 0x2000)
 
-#        platform.add_platform_command("""
-#NET "{usb_clk}" TNM_NET = "GRPusb_clk";
-#TIMESPEC "TSise_sucks11" = FROM "GRPusb_clk" TO "GRPsys_clk" TIG;
-#TIMESPEC "TSise_sucks12" = FROM "GRPsys_clk" TO "GRPusb_clk" TIG;
-#""", usb_clk=platform.lookup_request("fx2").ifclk)
+        platform.add_platform_command("""
+# Separate TMNs for FROM:TO TIG constraints
+NET "{usb_clk}" TNM_NET = "TIGusb_clk";
+TIMESPEC "TSusb_to_sys" = FROM "TIGusb_clk" TO "TIGsys_clk" TIG;
+TIMESPEC "TSsys_to_usb" = FROM "TIGsys_clk" TO "TIGusb_clk" TIG;
+""", usb_clk=platform.lookup_request("fx2").ifclk)
 
 
 default_subtarget = HDMI2USBSoC

--- a/targets/opsis_video.py
+++ b/targets/opsis_video.py
@@ -34,15 +34,17 @@ def CreateVideoMixerSoC(base):
                 platform.request("hdmi_in", 1),
                 self.sdram.crossbar.get_master(),
                 fifo_depth=512)
+
             self.submodules.hdmi_out0 = HDMIOut(
                 platform.request("hdmi_out", 0),
                 self.sdram.crossbar.get_master(),
+                clock50=ClockSignal(self.crg.cd_periph.name),
                 fifo_depth=1024)
             # Share clocking with hdmi_out0 since no PLL_ADV left.
             self.submodules.hdmi_out1 = HDMIOut(
                 platform.request("hdmi_out", 1),
                 self.sdram.crossbar.get_master(),
-                self.hdmi_out0.driver.clocking,
+                external_clocking=self.hdmi_out0.driver.clocking,
                 fifo_depth=1024)
 
             # all PLL_ADV are used: router needs help...
@@ -53,7 +55,8 @@ def CreateVideoMixerSoC(base):
             platform.add_platform_command(
                 """PIN "hdmi_out_pix_bufg_1.O" CLOCK_DEDICATED_ROUTE = FALSE;""")
             # We have CDC to go from sys_clk to pixel domain
-            platform.add_platform_command("""
+            platform.add_platform_command(
+                """
 # Separate TMNs for FROM:TO TIG constraints
 NET "{pix0_clk}" TNM_NET = "TIGpix0_clk";
 NET "{pix1_clk}" TNM_NET = "TIGpix1_clk";

--- a/targets/opsis_video.py
+++ b/targets/opsis_video.py
@@ -52,18 +52,16 @@ def CreateVideoMixerSoC(base):
                 """PIN "hdmi_out_pix_bufg.O" CLOCK_DEDICATED_ROUTE = FALSE;""")
             platform.add_platform_command(
                 """PIN "hdmi_out_pix_bufg_1.O" CLOCK_DEDICATED_ROUTE = FALSE;""")
-#            platform.add_platform_command(
-#                """
-#NET "{pix0_clk}" TNM_NET = "GRPpix0_clk";
-#NET "{pix1_clk}" TNM_NET = "GRPpix1_clk";
-#TIMESPEC "TSise_sucks7" = FROM "GRPpix0_clk" TO "GRPsys_clk" TIG;
-#TIMESPEC "TSise_sucks8" = FROM "GRPsys_clk" TO "GRPpix0_clk" TIG;
-#TIMESPEC "TSise_sucks9" = FROM "GRPpix1_clk" TO "GRPsys_clk" TIG;
-#TIMESPEC "TSise_sucks10" = FROM "GRPsys_clk" TO "GRPpix1_clk" TIG;
-#""",
-#                pix0_clk=self.hdmi_out0.driver.clocking.cd_pix.clk,
-#                pix1_clk=self.hdmi_out1.driver.clocking.cd_pix.clk,
-#            )
+            # We have CDC to go from sys_clk to pixel domain
+            platform.add_platform_command("""
+NET "{pix0_clk}" TNM_NET = "TIGpix_clk";
+NET "{pix1_clk}" TNM_NET = "TIGpix_clk";
+TIMESPEC "TSpix0_to_sys" = FROM "TIGpix_clk"  TO "TIGsys0_clk" TIG;
+TIMESPEC "TSsys_to_pix0" = FROM "TIGsys0_clk" TO "TIGpix_clk"  TIG;
+""",
+                pix0_clk=self.hdmi_out0.driver.clocking.cd_pix.clk,
+                pix1_clk=self.hdmi_out1.driver.clocking.cd_pix.clk,
+            )
 
             for k, v in sorted(platform.hdmi_infos.items()):
                 self.add_constant(k, v)

--- a/targets/opsis_video.py
+++ b/targets/opsis_video.py
@@ -1,3 +1,5 @@
+from migen.fhdl.std import ClockSignal
+
 from gateware.hdmi_in import HDMIIn
 from gateware.hdmi_out import HDMIOut
 

--- a/targets/opsis_video.py
+++ b/targets/opsis_video.py
@@ -54,10 +54,13 @@ def CreateVideoMixerSoC(base):
                 """PIN "hdmi_out_pix_bufg_1.O" CLOCK_DEDICATED_ROUTE = FALSE;""")
             # We have CDC to go from sys_clk to pixel domain
             platform.add_platform_command("""
-NET "{pix0_clk}" TNM_NET = "TIGpix_clk";
-NET "{pix1_clk}" TNM_NET = "TIGpix_clk";
-TIMESPEC "TSpix0_to_sys" = FROM "TIGpix_clk"  TO "TIGsys0_clk" TIG;
-TIMESPEC "TSsys_to_pix0" = FROM "TIGsys0_clk" TO "TIGpix_clk"  TIG;
+# Separate TMNs for FROM:TO TIG constraints
+NET "{pix0_clk}" TNM_NET = "TIGpix0_clk";
+NET "{pix1_clk}" TNM_NET = "TIGpix1_clk";
+TIMESPEC "TSpix0_to_sys" = FROM "TIGpix0_clk" TO "TIGsys_clk"  TIG;
+TIMESPEC "TSsys_to_pix0" = FROM "TIGsys_clk"  TO "TIGpix0_clk" TIG;
+TIMESPEC "TSpix1_to_sys" = FROM "TIGpix1_clk" TO "TIGsys_clk"  TIG;
+TIMESPEC "TSsys_to_pix1" = FROM "TIGsys_clk"  TO "TIGpix1_clk" TIG;
 """,
                 pix0_clk=self.hdmi_out0.driver.clocking.cd_pix.clk,
                 pix1_clk=self.hdmi_out1.driver.clocking.cd_pix.clk,

--- a/targets/opsis_video.py
+++ b/targets/opsis_video.py
@@ -44,7 +44,7 @@ def CreateVideoMixerSoC(base):
                 self.sdram.crossbar.get_master(),
                 self.hdmi_out0.driver.clocking,
                 fifo_depth=1024)
-    
+
             # all PLL_ADV are used: router needs help...
             platform.add_platform_command("""INST PLL_ADV LOC=PLL_ADV_X0Y0;""")
             # FIXME: Fix the HDMI out so this can be removed.
@@ -52,18 +52,18 @@ def CreateVideoMixerSoC(base):
                 """PIN "hdmi_out_pix_bufg.O" CLOCK_DEDICATED_ROUTE = FALSE;""")
             platform.add_platform_command(
                 """PIN "hdmi_out_pix_bufg_1.O" CLOCK_DEDICATED_ROUTE = FALSE;""")
-            platform.add_platform_command(
-                """
-NET "{pix0_clk}" TNM_NET = "GRPpix0_clk";
-NET "{pix1_clk}" TNM_NET = "GRPpix1_clk";
-TIMESPEC "TSise_sucks7" = FROM "GRPpix0_clk" TO "GRPsys_clk" TIG;
-TIMESPEC "TSise_sucks8" = FROM "GRPsys_clk" TO "GRPpix0_clk" TIG;
-TIMESPEC "TSise_sucks9" = FROM "GRPpix1_clk" TO "GRPsys_clk" TIG;
-TIMESPEC "TSise_sucks10" = FROM "GRPsys_clk" TO "GRPpix1_clk" TIG;
-""", 
-                pix0_clk=self.hdmi_out0.driver.clocking.cd_pix.clk,
-                pix1_clk=self.hdmi_out1.driver.clocking.cd_pix.clk,
-            )
+#            platform.add_platform_command(
+#                """
+#NET "{pix0_clk}" TNM_NET = "GRPpix0_clk";
+#NET "{pix1_clk}" TNM_NET = "GRPpix1_clk";
+#TIMESPEC "TSise_sucks7" = FROM "GRPpix0_clk" TO "GRPsys_clk" TIG;
+#TIMESPEC "TSise_sucks8" = FROM "GRPsys_clk" TO "GRPpix0_clk" TIG;
+#TIMESPEC "TSise_sucks9" = FROM "GRPpix1_clk" TO "GRPsys_clk" TIG;
+#TIMESPEC "TSise_sucks10" = FROM "GRPsys_clk" TO "GRPpix1_clk" TIG;
+#""",
+#                pix0_clk=self.hdmi_out0.driver.clocking.cd_pix.clk,
+#                pix1_clk=self.hdmi_out1.driver.clocking.cd_pix.clk,
+#            )
 
             for k, v in sorted(platform.hdmi_infos.items()):
                 self.add_constant(k, v)

--- a/targets/pipistrello_base.py
+++ b/targets/pipistrello_base.py
@@ -25,75 +25,126 @@ from targets.common import *
 
 class _CRG(Module):
     def __init__(self, platform, clk_freq):
+        # Clock domains for the system (soft CPU and related components run at).
         self.clock_domains.cd_sys = ClockDomain()
+        # Clock domains for the DDR interface.
         self.clock_domains.cd_sdram_half = ClockDomain()
         self.clock_domains.cd_sdram_full_wr = ClockDomain()
         self.clock_domains.cd_sdram_full_rd = ClockDomain()
-        self.clock_domains.cd_base50 = ClockDomain()
-        self.clock_domains.cd_por = ClockDomain()
+        # Clock domain for peripherals (such as HDMI output).
+        self.clock_domains.cd_periph = ClockDomain()
 
-        self.clk4x_wr_strb = Signal()
-        self.clk4x_rd_strb = Signal()
+        # Input 50MHz clock
+        f0 = 50 * MHz
+        clk50 = platform.request("clk50")
+        clk50a = Signal()
+        # Input 50MHz clock (buffered)
+        self.specials += Instance("IBUFG", i_I=clk50, o_O=clk50a)
+        clk50b = Signal()
+        self.specials += Instance(
+            "BUFIO2", p_DIVIDE=1,
+            p_DIVIDE_BYPASS="TRUE", p_I_INVERT="FALSE",
+            i_I=clk50a, o_DIVCLK=clk50b)
 
-        f0 = Fraction(50, 1)*1000000
         p = 12
         f = Fraction(clk_freq*p, f0)
         n, d = f.numerator, f.denominator
-        print("n/d : {}/{}".format(n ,d))
         assert 19e6 <= f0/d <= 500e6  # pfd
         assert 400e6 <= f0*n/d <= 1080e6  # vco
 
-        clk50 = platform.request("clk50")
-        clk50a = Signal()
-        self.specials += Instance("IBUFG", i_I=clk50, o_O=clk50a)
-        clk50b = Signal()
-        self.specials += Instance("BUFIO2", p_DIVIDE=1,
-                                  p_DIVIDE_BYPASS="TRUE", p_I_INVERT="FALSE",
-                                  i_I=clk50a, o_DIVCLK=clk50b)
+        print("p=", p, "n=", n, "d=", d)
+
+        # Unbuffered output signals from the PLL. They need to be buffered
+        # before feeding into the fabric.
+        unbuf_sdram_full = Signal()
+        unbuf_sdram_half_a = Signal()
+        unbuf_sdram_half_b = Signal()
+        unbuf_encoder = Signal()
+        unbuf_sys = Signal()
+        unbuf_periph = Signal()
+
+        # PLL signals
         pll_lckd = Signal()
         pll_fb = Signal()
-        pll = Signal(6)
-        self.specials.pll = Instance("PLL_ADV", p_SIM_DEVICE="SPARTAN6",
-                                     p_BANDWIDTH="OPTIMIZED", p_COMPENSATION="INTERNAL",
-                                     p_REF_JITTER=.01, p_CLK_FEEDBACK="CLKFBOUT",
-                                     i_DADDR=0, i_DCLK=0, i_DEN=0, i_DI=0, i_DWE=0, i_RST=0, i_REL=0,
-                                     p_DIVCLK_DIVIDE=d, p_CLKFBOUT_MULT=n, p_CLKFBOUT_PHASE=0.,
-                                     i_CLKIN1=clk50b, i_CLKIN2=0, i_CLKINSEL=1,
-                                     p_CLKIN1_PERIOD=1e9/f0, p_CLKIN2_PERIOD=0.,
-                                     i_CLKFBIN=pll_fb, o_CLKFBOUT=pll_fb, o_LOCKED=pll_lckd,
-                                     o_CLKOUT0=pll[0], p_CLKOUT0_DUTY_CYCLE=.5,
-                                     o_CLKOUT1=pll[1], p_CLKOUT1_DUTY_CYCLE=.5,
-                                     o_CLKOUT2=pll[2], p_CLKOUT2_DUTY_CYCLE=.5,
-                                     o_CLKOUT3=pll[3], p_CLKOUT3_DUTY_CYCLE=.5,
-                                     o_CLKOUT4=pll[4], p_CLKOUT4_DUTY_CYCLE=.5,
-                                     o_CLKOUT5=pll[5], p_CLKOUT5_DUTY_CYCLE=.5,
-                                     p_CLKOUT0_PHASE=0., p_CLKOUT0_DIVIDE=p//4,  # sdram wr rd
-                                     p_CLKOUT1_PHASE=0., p_CLKOUT1_DIVIDE=p//4,
-                                     p_CLKOUT2_PHASE=270., p_CLKOUT2_DIVIDE=p//2,  # sdram dqs adr ctrl
-                                     p_CLKOUT3_PHASE=250., p_CLKOUT3_DIVIDE=p//2,  # off-chip ddr
-                                     p_CLKOUT4_PHASE=0., p_CLKOUT4_DIVIDE=p//1,
-                                     p_CLKOUT5_PHASE=0., p_CLKOUT5_DIVIDE=p//1,  # sys
+        self.specials.pll = Instance(
+            "PLL_ADV",
+            p_SIM_DEVICE="SPARTAN6", p_BANDWIDTH="OPTIMIZED", p_COMPENSATION="INTERNAL",
+            p_REF_JITTER=.01,
+            i_DADDR=0, i_DCLK=0, i_DEN=0, i_DI=0, i_DWE=0, i_RST=0, i_REL=0,
+            p_DIVCLK_DIVIDE=d,
+            # Input Clocks (50MHz)
+            i_CLKIN1=clk50b,
+            p_CLKIN1_PERIOD=f0.to_ns(),
+            i_CLKIN2=0,
+            p_CLKIN2_PERIOD=0.,
+            i_CLKINSEL=1,
+            # Feedback
+            i_CLKFBIN=pll_fb, o_CLKFBOUT=pll_fb, o_LOCKED=pll_lckd,
+            p_CLK_FEEDBACK="CLKFBOUT",
+            p_CLKFBOUT_MULT=n, p_CLKFBOUT_PHASE=0.,
+            # (333MHz) sdram wr rd
+            o_CLKOUT0=unbuf_sdram_full, p_CLKOUT0_DUTY_CYCLE=.5,
+            p_CLKOUT0_PHASE=0., p_CLKOUT0_DIVIDE=p//4,
+            # ( 66MHz) encoder
+            o_CLKOUT1=unbuf_encoder, p_CLKOUT1_DUTY_CYCLE=.5,
+            p_CLKOUT1_PHASE=0., p_CLKOUT1_DIVIDE=15,
+            # (166MHz) sdram_half - sdram dqs adr ctrl
+            o_CLKOUT2=unbuf_sdram_half_a, p_CLKOUT2_DUTY_CYCLE=.5,
+            p_CLKOUT2_PHASE=270., p_CLKOUT2_DIVIDE=p//2,
+            # (166MHz) off-chip ddr
+            o_CLKOUT3=unbuf_sdram_half_b, p_CLKOUT3_DUTY_CYCLE=.5,
+            p_CLKOUT3_PHASE=250., p_CLKOUT3_DIVIDE=p//2,
+            # ( 50MHz) periph
+            o_CLKOUT4=unbuf_periph, p_CLKOUT4_DUTY_CYCLE=.5,
+            p_CLKOUT4_PHASE=0., p_CLKOUT4_DIVIDE=20,
+            # ( 83MHz) sysclk
+            o_CLKOUT5=unbuf_sys, p_CLKOUT5_DUTY_CYCLE=.5,
+            p_CLKOUT5_PHASE=0., p_CLKOUT5_DIVIDE=p//1,
         )
-        self.specials += Instance("BUFG", i_I=pll[5], o_O=self.cd_sys.clk)
+
+        # assert the clocks turned out as requested.
+        assert_pll_clock(333 * MHz, input=f0/d, feedback=n, divide=(p//4), msg="CLKOUT0")
+        assert_pll_clock( 66 * MHz, input=f0/d, feedback=n, divide=(15  ), msg="CLKOUT1")
+        assert_pll_clock(166 * MHz, input=f0/d, feedback=n, divide=(p//2), msg="CLKOUT2 && CLKOUT3")
+        assert_pll_clock( 50 * MHz, input=f0/d, feedback=n, divide=(20  ), msg="CLKOUT4")
+        assert_pll_clock( 83 * MHz, input=f0/d, feedback=n, divide=(p//1), msg="CLKOUT5")
+
+        # power on reset?
         reset = platform.request("user_btn")
-        self.comb += self.cd_base50.clk.eq(clk50a)
+        self.clock_domains.cd_por = ClockDomain()
         por = Signal(max=1 << 11, reset=(1 << 11) - 1)
-        self.specials += AsyncResetSynchronizer(self.cd_base50, por > 0)
         self.sync.por += If(por != 0, por.eq(por - 1))
-        self.comb += self.cd_por.clk.eq(self.cd_sys.clk)
         self.specials += AsyncResetSynchronizer(self.cd_por, reset)
+
+        # System clock - 75MHz
+        self.specials += Instance("BUFG", i_I=unbuf_sys, o_O=self.cd_sys.clk)
+        self.comb += self.cd_por.clk.eq(self.cd_sys.clk)
         self.specials += AsyncResetSynchronizer(self.cd_sys, ~pll_lckd | (por > 0))
-        self.specials += Instance("BUFG", i_I=pll[2], o_O=self.cd_sdram_half.clk)
+
+        # Peripheral clock - 50MHz
+        # The peripheral clock is kept separate from the system clock to allow
+        # the system clock to be increased in the future.
+        self.specials += Instance("BUFG", i_I=unbuf_periph, o_O=self.cd_periph.clk)
+        self.specials += AsyncResetSynchronizer(self.cd_periph, self.cd_sys.rst)
+
+        # SDRAM clocks
+        # ------------------------------------------------------------------------------
+        self.clk4x_wr_strb = Signal()
+        self.clk4x_rd_strb = Signal()
+
+        # sdram_full
         self.specials += Instance("BUFPLL", p_DIVIDE=4,
-                                  i_PLLIN=pll[0], i_GCLK=self.cd_sys.clk,
+                                  i_PLLIN=unbuf_sdram_full, i_GCLK=self.cd_sys.clk,
                                   i_LOCKED=pll_lckd, o_IOCLK=self.cd_sdram_full_wr.clk,
                                   o_SERDESSTROBE=self.clk4x_wr_strb)
         self.comb += [
             self.cd_sdram_full_rd.clk.eq(self.cd_sdram_full_wr.clk),
             self.clk4x_rd_strb.eq(self.clk4x_wr_strb),
         ]
+        # sdram_half
+        self.specials += Instance("BUFG", i_I=unbuf_sdram_half_a, o_O=self.cd_sdram_half.clk)
         clk_sdram_half_shifted = Signal()
-        self.specials += Instance("BUFG", i_I=pll[3], o_O=clk_sdram_half_shifted)
+        self.specials += Instance("BUFG", i_I=unbuf_sdram_half_b, o_O=clk_sdram_half_shifted)
         clk = platform.request("ddram_clock")
         self.specials += Instance("ODDR2", p_DDR_ALIGNMENT="NONE",
                                   p_INIT=0, p_SRTYPE="SYNC",
@@ -142,7 +193,7 @@ class BaseSoC(SDRAMSoC):
                  firmware_ram_size=0xa000,
                  firmware_filename=None,
                  **kwargs):
-        clk_freq = (83 + Fraction(1, 3))*1000*1000
+        clk_freq = (83 + Fraction(1, 3)) * MHz
         SDRAMSoC.__init__(self, platform, clk_freq,
                           integrated_rom_size=0x8000,
                           sdram_controller_settings=LASMIconSettings(l2_size=32, with_bandwidth=True),
@@ -161,11 +212,13 @@ class BaseSoC(SDRAMSoC):
         self.add_constant("ROM_BOOT_ADDRESS", self.mem_map["firmware_ram"])
 
         if not self.integrated_main_ram_size:
-            self.submodules.ddrphy = s6ddrphy.S6HalfRateDDRPHY(platform.request("ddram"),
-                                                               MT46H32M16(self.clk_freq),
-                                                               rd_bitslip=1,
-                                                               wr_bitslip=3,
-                                                               dqs_ddr_alignment="C1")
+            self.submodules.ddrphy = s6ddrphy.S6HalfRateDDRPHY(
+                platform.request("ddram"),
+                MT46H32M16(self.clk_freq),
+                rd_bitslip=1,
+                wr_bitslip=3,
+                dqs_ddr_alignment="C1",
+            )
             self.comb += [
                 self.ddrphy.clk4x_wr_strb.eq(self.crg.clk4x_wr_strb),
                 self.ddrphy.clk4x_rd_strb.eq(self.crg.clk4x_rd_strb),
@@ -190,7 +243,8 @@ class VideomixerSoC(BaseSoC):
     def __init__(self, platform, **kwargs):
         BaseSoC.__init__(self, platform, **kwargs)
         self.submodules.hdmi_out0 = hdmi_out.HDMIOut(
-            platform.request("hdmi", 0), self.sdram.crossbar.get_master())
+            platform.request("hdmi", 0), self.sdram.crossbar.get_master(),
+            clock50=ClockSignal(self.crg.cd_periph.name))
 
         platform.add_platform_command("""PIN "hdmi_out_pix_bufg.O" CLOCK_DEDICATED_ROUTE = FALSE;""")
 

--- a/targets/pipistrello_base.py
+++ b/targets/pipistrello_base.py
@@ -52,8 +52,6 @@ class _CRG(Module):
         assert 19e6 <= f0/d <= 500e6  # pfd
         assert 400e6 <= f0*n/d <= 1080e6  # vco
 
-        print("p=", p, "n=", n, "d=", d)
-
         # Unbuffered output signals from the PLL. They need to be buffered
         # before feeding into the fabric.
         unbuf_sdram_full = Signal()


### PR DESCRIPTION
Fixes #210.

This pull request make a bunch of changes to improve the code around PLL and timing constraints. 

These are;
 * Better naming of the clock signals.
 * Adding a `class` for the frequency to make it easier to understand.
 * Improving the documentation around the CRG module and PLL configuration. 
 * Asserting the PLL configuration is as requested.
 * Improving the timing constraint names and making them easier to understand.
