### PR TITLE
targets/atlys: Revert to using BaseSoC rather than MiniSoC.

### DIFF
--- a/targets/atlys_base.py
+++ b/targets/atlys_base.py
@@ -219,4 +219,4 @@ TIMESPEC "TSise_sucks4" = FROM "GRPsys_clk" TO "GRPeth_rx_clk" TIG;
      eth_clocks_tx=platform.lookup_request("eth_clocks").tx)
 
 
-default_subtarget = MiniSoC
+default_subtarget = BaseSoC


### PR DESCRIPTION
Fixes #289.

This seems to have been an accident in
https://github.com/timvideos/HDMI2USB-misoc-firmware/commit/075107405196f9fa3158e9da8a0ca7d54641286c#diff-2b70f9cc5d7a3571d43b4c7a4fc67fa6R225